### PR TITLE
update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ZClassic 2.0.4
+ZClassic 2.0.4.1
 <img align="right" width="120" height="80" src="doc/imgs/logo.png">
 ===========
 


### PR DESCRIPTION
2.0.4.1 should reflect the change in deprecation policy block height (it became suppressed without updating versions of zcash codebase)