### PR TITLE
Update zcbenchmarks.cpp (solved build error on mac os)

### DIFF
--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -453,9 +453,11 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
 // This class is based on the class CCoinsViewDB, but with limited functionality.
 // The construtor and the functions `GetCoins` and `HaveCoins` come directly from
 // CCoinsViewDB, but the rest are either mocks and/or don't really do anything.
+
+// The following constant is a duplicate of the one found in txdb.cpp
+static const char DB_COINS = 'c';
+
 class FakeCoinsViewDB : public CCoinsView {
-    // The following constant is a duplicate of the one found in txdb.cpp
-    static const char DB_COINS = 'c';
 
     CDBWrapper db;
 


### PR DESCRIPTION
Implement zcash fix in order to avoid error during  mac os build.