### PR TITLE
extend deprecation to over 9000 weeks from release

### DIFF
--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -9,7 +9,7 @@
 // * Shut down 16 weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
 static const int APPROX_RELEASE_HEIGHT = 1597400;
-static const int WEEKS_UNTIL_DEPRECATION = 16;
+static const int WEEKS_UNTIL_DEPRECATION = 9001;
 static const int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
 
 // Number of blocks before deprecation to warn users


### PR DESCRIPTION
set `WEEKS_UNTIL_DEPRECATION` to over 9000 so that nodes continue to tick along when there are no new releases