### PR TITLE
fix build:  Change Boost dld path to Official archives

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_80_0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source
+$(package)_download_path=https://archives.boost.io/release/1.80.0/source
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0
 $(package)_patches=fix-macos-linker.patch


### PR DESCRIPTION
https://boostorg.jfrog.io was throwing a 403 at my side, causing the `build.sh` to fail

change it to use official boost archives @ https://www.boost.org/releases/1.80.0/

the sha256 hash is the same: `1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0`