### PR TITLE
Disable the `Alert System` inherited from ZEC/BTC

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -172,96 +172,12 @@ CAlert CAlert::getAlertByHash(const uint256 &hash)
 
 bool CAlert::ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThread)
 {
-    if (!CheckSignature(alertKey))
-        return false;
-    if (!IsInEffect())
-        return false;
-
-    // alert.nID=max is reserved for if the alert key is
-    // compromised. It must have a pre-defined message,
-    // must never expire, must apply to all versions,
-    // and must cancel all previous
-    // alerts or it will be ignored (so an attacker can't
-    // send an "everything is OK, don't panic" version that
-    // cannot be overridden):
-    int maxInt = std::numeric_limits<int>::max();
-    if (nID == maxInt)
-    {
-        if (!(
-                nExpiration == maxInt &&
-                nCancel == (maxInt-1) &&
-                nMinVer == 0 &&
-                nMaxVer == maxInt &&
-                setSubVer.empty() &&
-                nPriority == maxInt &&
-                strStatusBar == "URGENT: Alert key compromised, upgrade required"
-                ))
-            return false;
-    }
-
-    {
-        LOCK(cs_mapAlerts);
-        // Cancel previous alerts
-        for (map<uint256, CAlert>::iterator mi = mapAlerts.begin(); mi != mapAlerts.end();)
-        {
-            const CAlert& alert = (*mi).second;
-            if (Cancels(alert))
-            {
-                LogPrint("alert", "cancelling alert %d\n", alert.nID);
-                uiInterface.NotifyAlertChanged((*mi).first, CT_DELETED);
-                mapAlerts.erase(mi++);
-            }
-            else if (!alert.IsInEffect())
-            {
-                LogPrint("alert", "expiring alert %d\n", alert.nID);
-                uiInterface.NotifyAlertChanged((*mi).first, CT_DELETED);
-                mapAlerts.erase(mi++);
-            }
-            else
-                mi++;
-        }
-
-        // Check if this alert has been cancelled
-        BOOST_FOREACH(PAIRTYPE(const uint256, CAlert)& item, mapAlerts)
-        {
-            const CAlert& alert = item.second;
-            if (alert.Cancels(*this))
-            {
-                LogPrint("alert", "alert already cancelled by %d\n", alert.nID);
-                return false;
-            }
-        }
-
-        // Add to mapAlerts
-        mapAlerts.insert(make_pair(GetHash(), *this));
-        // Notify UI and -alertnotify if it applies to me
-        if(AppliesToMe())
-        {
-            uiInterface.NotifyAlertChanged(GetHash(), CT_NEW);
-            Notify(strStatusBar, fThread);
-        }
-    }
-
-    LogPrint("alert", "accepted alert %d, AppliesToMe()=%d\n", nID, AppliesToMe());
-    return true;
+    // disable the alert system
+    return false;
 }
 
-void
-CAlert::Notify(const std::string& strMessage, bool fThread)
+void CAlert::Notify(const std::string& strMessage, bool fThread)
 {
-    std::string strCmd = GetArg("-alertnotify", "");
-    if (strCmd.empty()) return;
-
-    // Alert text should be plain ascii coming from a trusted source, but to
-    // be safe we first strip anything not in safeChars, then add single quotes around
-    // the whole string before passing it to the shell:
-    std::string singleQuote("'");
-    std::string safeStatus = SanitizeString(strMessage);
-    safeStatus = singleQuote+safeStatus+singleQuote;
-    boost::replace_all(strCmd, "%s", safeStatus);
-
-    if (fThread)
-        boost::thread t(runCommand, strCmd); // thread runs free
-    else
-        runCommand(strCmd);
+    // disable the alert system
+    return;
 }


### PR DESCRIPTION
**_security issue:_**  i actually removed this back in 2016 (see https://github.com/hairetikos/zclassic-103-master/commit/df7549d1e6f80e31b1bda2870d4cab6d6a49ffb6 and other commits), but it seems it got reinserted when ZCL re-forked the newer ZEC `Sapling` upgrade back then to fix the `Sprout` security issues.

this is the quickest way to disable the Alert System without having to touch the rest of the code:

(just return/return false immediately)

we can fully purge the unused code later on when also removing things like Onion V2 code (as we have Onion V3 now), and compiling with LTO can already remove dead code too.

**note**:  the `ProcessAlert` return of `false` means the P2P handler in `main.cpp` will call `Misbehaving` for every alert message received.  this is actually desirable... **nodes trying to abuse the alert system will eventually get banned.**