### PR TITLE
fix `onion=` outbound when `proxy=` is not specified

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1457,6 +1457,26 @@ void ThreadOpenAddedConnections()
 
         list<vector<CService> > lservAddressesToAdd(0);
         BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
+            // Detect .onion addresses — they cannot be DNS-resolved.
+            // Route them through the NET_ONION proxy (set by -onion=) if available,
+            // using the string-based ConnectSocketByName path.
+            {
+                std::string strHost;
+                int nPort = Params().GetDefaultPort();
+                SplitHostPort(strAddNode, nPort, strHost);
+                if (strHost.size() > 6 &&
+                    strHost.substr(strHost.size() - 6) == ".onion")
+                {
+                    proxyType onionProxy;
+                    if (GetProxy(NET_ONION, onionProxy)) {
+                        CSemaphoreGrant grant(*semOutbound);
+                        OpenNetworkConnection(CAddress(), &grant, strAddNode.c_str());
+                        MilliSleep(500);
+                    }
+                    continue;
+                }
+            }
+
             vector<CService> vservNode(0);
             if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
             {


### PR DESCRIPTION
this was a bug/quirk inherited from earlier BTC/Zcash code

_quirk_:  when zclassic was configured with `onion=127.0.0.1:9050` but WITHOUT also `proxy=127.0.0.1:9050`, it caused outbound onion V3 to silently fail, but inbound V3 was working.

_use-case:_  we want this configuration to work for example in a scenario where you want a node to have IPv4 + IPv6 over regular network, not via proxy (or an independent `proxy=`), but then allow Onion V3 exclusively via the onion proxy, as specified just with `onion=`.

`proxy=` can still be used together with `onion=` to have a different proxy for IPv4+6, independent from onion proxy/

_technical cause_:  When a node uses -onion= without -proxy=, HaveNameProxy() returns false, causing ThreadOpenAddedConnections() to take the Lookup() branch — which silently drops .onion addnode peers since they can't be DNS-resolved.

Added support for .onion addresses routing through the NET_ONION proxy even when `proxy=` is not specified along with `onion=`