### PR TITLE
Fix build for GCC 15 and add Arch Linux support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ This guide will help you build `zclassicd` (ZClassic daemon) from source code.
 
 ## System Requirements
 
-- **Operating System**: Ubuntu 20.04+, Debian 11+, or compatible Linux distribution
+- **Operating System**: Ubuntu 20.04+, Debian 11+, Arch Linux, Manjaro, or compatible Linux distribution
 - **Memory**: At least 4 GB RAM recommended
 - **Disk Space**: 20 GB free space (for build files and blockchain data)
 - **Compiler**: GCC 9+ or Clang 10+
@@ -46,6 +46,15 @@ sudo apt-get install -y \
     libgmp-dev libdb++-dev libsodium-dev \
     git python3 wget curl \
     zlib1g-dev libssl-dev libevent-dev
+```
+
+#### Arch Linux / Manjaro
+
+```bash
+sudo pacman -S --needed \
+    base-devel autoconf automake libtool pkgconf \
+    gmp db libsodium curl \
+    git python wget openssl libevent
 ```
 
 #### Other Distributions
@@ -147,11 +156,15 @@ If bootstrap snapshot installation fails:
 
 ```bash
 # Build only the dependencies
-make -C depends -j$(nproc)
+make -C depends -j$(nproc) NO_PROTON=1
 
 # Then configure with the dependencies
 ./autogen.sh
-CONFIG_SITE=$PWD/depends/x86_64-unknown-linux-gnu/share/config.site ./configure
+DEPS_DIR=$PWD/depends/x86_64-unknown-linux-gnu
+CONFIG_SITE=$DEPS_DIR/share/config.site ./configure \
+    --with-boost=$DEPS_DIR \
+    CPPFLAGS="-I$DEPS_DIR/include" \
+    LDFLAGS="-L$DEPS_DIR/lib"
 make -j$(nproc)
 ```
 

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -1,5 +1,5 @@
-linux_CFLAGS=-pipe
-linux_CXXFLAGS=$(linux_CFLAGS)
+linux_CFLAGS=-pipe -std=gnu17
+linux_CXXFLAGS=-pipe -std=gnu++17
 
 linux_release_CFLAGS=-O1
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -456,7 +456,7 @@ double benchmark_increment_sapling_note_witnesses(size_t nTxs)
 // CCoinsViewDB, but the rest are either mocks and/or don't really do anything.
 class FakeCoinsViewDB : public CCoinsView {
     // The following constant is a duplicate of the one found in txdb.cpp
-    static const char DB_COINS = 'c';
+    static constexpr char DB_COINS = 'c';
 
     CDBWrapper db;
 
@@ -488,11 +488,13 @@ public:
     }
 
     bool GetCoins(const uint256 &txid, CCoins &coins) const {
-        return db.Read(std::make_pair(DB_COINS, txid), coins);
+        char key = DB_COINS;
+        return db.Read(std::make_pair(key, txid), coins);
     }
 
     bool HaveCoins(const uint256 &txid) const {
-        return db.Exists(std::make_pair(DB_COINS, txid));
+        char key = DB_COINS;
+        return db.Exists(std::make_pair(key, txid));
     }
 
     uint256 GetBestBlock() const {

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -103,5 +103,14 @@ ld -v
 
 HOST="$HOST" BUILD="$BUILD" NO_PROTON="$PROTON_ARG" "$MAKE" "$@" -C ./depends/ V=1
 ./autogen.sh
-CONFIG_SITE="$PWD/depends/$HOST/share/config.site" ./configure "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" $CONFIGURE_FLAGS CXXFLAGS='-g'
+
+DEPS_DIR="$PWD/depends/$HOST"
+CONFIG_SITE="$DEPS_DIR/share/config.site" ./configure \
+  "$HARDENING_ARG" "$LCOV_ARG" "$TEST_ARG" "$MINING_ARG" "$PROTON_ARG" \
+  --with-boost="$DEPS_DIR" \
+  $CONFIGURE_FLAGS \
+  CXXFLAGS='-g' \
+  CPPFLAGS="-I$DEPS_DIR/include" \
+  LDFLAGS="-L$DEPS_DIR/lib"
+
 "$MAKE" "$@" V=1

--- a/zcutil/install-deps.sh
+++ b/zcutil/install-deps.sh
@@ -26,7 +26,7 @@ if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS=$ID
 else
-    echo "Cannot detect OS. This script supports Ubuntu/Debian."
+    echo "Cannot detect OS. This script supports Ubuntu/Debian and Arch-based distributions."
     exit 1
 fi
 
@@ -111,14 +111,47 @@ install_mingw_toolchain() {
     echo "✓ mingw-w64 toolchain installed ($(x86_64-w64-mingw32-g++ -dumpversion 2>/dev/null), thread model: $(x86_64-w64-mingw32-g++ -v 2>&1 | sed -n 's/^Thread model: //p'))"
 }
 
+install_arch() {
+    echo "Installing dependencies for Arch/Manjaro..."
+    echo ""
+
+    PACKAGES=(
+        base-devel
+        autoconf
+        automake
+        libtool
+        pkgconf
+        gmp
+        db
+        libsodium
+        curl
+        git
+        python
+        wget
+        openssl
+        libevent
+    )
+
+    echo "Installing packages: ${PACKAGES[*]}"
+    echo ""
+
+    $SUDO pacman -S --needed --noconfirm "${PACKAGES[@]}"
+
+    echo ""
+    echo "All dependencies installed successfully!"
+}
+
 case "$OS" in
     ubuntu|debian|linuxmint|pop)
         install_ubuntu_debian
         [ "$WITH_MINGW" -eq 1 ] && install_mingw_toolchain
         ;;
+    arch|manjaro|endeavouros|garuda)
+        install_arch
+        ;;
     *)
         echo "Unsupported OS: $OS"
-        echo "This script currently supports Ubuntu and Debian-based distributions."
+        echo "This script supports Ubuntu/Debian and Arch-based distributions."
         echo ""
         echo "Required packages:"
         echo "  - build-essential, autoconf, libtool, automake"


### PR DESCRIPTION
## Summary

- Fix GCC 15 / C23 compatibility in depends build system by setting `-std=gnu17` / `-std=gnu++17` CFLAGS
- Fix `FakeCoinsViewDB::DB_COINS` ODR-use link failure with GCC 15
- Fix `build.sh` to pass explicit `--with-boost`, `CPPFLAGS`, and `LDFLAGS` to configure, resolving unreliable `depends_prefix` resolution in config.site with newer autoconf
- Add Arch Linux / Manjaro / EndeavourOS / Garuda support to `install-deps.sh`
- Update `BUILD.md` with Arch Linux build instructions

## Details

**GCC 15 + GMP 6.3.0**: GCC 15 defaults to C23 where `void g(){}` means "no parameters". GMP's configure test calls such a function with arguments, causing the compiler reliability test to fail. Setting `-std=gnu17` restores the old behavior.

**ODR violation**: `static const char DB_COINS = 'c'` in `FakeCoinsViewDB` is ODR-used by `std::make_pair` (taken by const reference). GCC 15 enforces this strictly. Fixed by copying to a local variable.

**config.site boost detection**: The `depends_prefix` backtick expansion in config.site can fail with newer autoconf versions, causing `--with-boost` to resolve to an empty path. Passing explicit paths on the configure command line is more reliable.

## Test plan

- [x] Built successfully on Manjaro Linux with GCC 15.2.1
- [x] All three binaries produced: `zclassicd`, `zclassic-cli`, `zclassic-tx`
- [ ] Verify build still works on Ubuntu/Debian