### PR TITLE
bootstrap: retry snapshot download before P2P fallback (reliable no-flag fast-sync)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1987,14 +1987,28 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     InitWarning(_("EXPERIMENTAL: -bootstrapmode=trustless accepts a peer's self-snapshot provisionally and re-derives the UTXO set from genesis in the background, reindexing if it does not validate. WARNING: until validation completes (which can take as long as a full sync), the node operates on an UNVERIFIED UTXO set; do not rely on balances or spend received funds until getblockchaininfo reports bootstrap_validation state \"validated\"."));
                 else
                     InitWarning(_("Bootstrap snapshots are trusted input; the snapshot tip is verified against the compiled anchor."));
+                // Retry each peer a few times before giving up. A single transient
+                // hiccup (a brief connection blip, a serve-side snapshot refresh, a
+                // momentary stall on a lossy link) otherwise drops a fresh node
+                // SILENTLY into peerless P2P sync and it appears to hang at 0 blocks.
+                // Each BootstrapFromPeer attempt is self-contained (it stages into a
+                // fresh dir and cleans up on failure), so retrying is safe and cheap.
+                const int nBootstrapAttempts = 3;
                 BOOST_FOREACH(const std::string& peer, GetBootstrapPeerList()) {
                     if (ShutdownRequested())
                         break;
-                    if (BootstrapFromPeer(peer, GetDataDir(), bootstrap_error)) {
-                        bootstrap_snapshot_ran = true;
-                        break;
+                    for (int attempt = 1; attempt <= nBootstrapAttempts && !ShutdownRequested(); ++attempt) {
+                        if (BootstrapFromPeer(peer, GetDataDir(), bootstrap_error)) {
+                            bootstrap_snapshot_ran = true;
+                            break;
+                        }
+                        LogPrintf("Bootstrap snapshot from %s failed (attempt %d/%d): %s\n",
+                                  peer, attempt, nBootstrapAttempts, bootstrap_error);
+                        if (attempt < nBootstrapAttempts)
+                            MilliSleep(3000); // brief backoff before retrying
                     }
-                    LogPrintf("Bootstrap snapshot from %s failed: %s\n", peer, bootstrap_error);
+                    if (bootstrap_snapshot_ran)
+                        break;
                 }
                 // If the explicit/compiled peers didn't work and the operator did
                 // not pin a specific peer, OPTIONALLY fall back to peers discovered


### PR DESCRIPTION
Makes a no-flag `zclassicd` reliably fast-sync. The compiled-peer bootstrap was single-attempt + silent fallback: one transient hiccup (brief connection blip, serve-side snapshot refresh, momentary stall on a lossy link) dropped a fresh node into peerless P2P sync, appearing to hang at 0 blocks / 0 connections.

Fix: retry each bootstrap peer up to 3× with a short backoff before falling back. Each attempt is self-contained (fresh staging, cleaned up on failure), so retrying is safe.

Observed in the wild: a fresh `./zclassicd` stranded at 0/0 after one transient miss; re-running worked immediately (confirming transient). This removes the foot-gun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)