### PR TITLE
GUI smoothness: 100% sync display, estimatedheight, unfrozen + faster startup

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -186,11 +186,15 @@ public:
             ( 2013514, uint256S("0x000019679aa2ea97a3f18bd9265bc91a09929ea0b1acc0fc5ef77cdf3cf906e7"))
             ( 2879438, uint256S("0x000007e8fccb9e4831c7d7376a283b016ead6166491f951f4f083dbe366992b2"))
             ( 3126937, uint256S("0x00000663e40f1fe0bc32a7e7282fac25de5fe8ecefd9c627e2fd948d388f7053")),
-            1779903078,     // * UNIX timestamp of last checkpoint block (May 27, 2026)
-            5293850,        // * total number of transactions between genesis and last checkpoint
-                            //   (estimated based on block height progression)
-            1060            // * estimated number of transactions per day after checkpoint
-                            //   total number of tx / (checkpoint block height / (24 * 24))
+            1780195595,     // * UNIX timestamp of the verificationprogress reference block
+                            //   (mainnet height 3130800, 2026-05-31)
+            5121107,        // * cumulative transactions (nChainTx) at that block, MEASURED off a
+                            //   synced node. Used ONLY by GuessVerificationProgress -- never by
+                            //   consensus, validation, or the fast-sync anchor commitment. The
+                            //   previous value (5293850) was a height-based estimate that overshot
+                            //   the real chain, so a fully-synced node was stuck below this phantom
+                            //   target and verificationprogress capped at ~0.96 forever.
+            1138            // * recent transactions/day (measured: ~1.0 tx/block, ~1138 blocks/day)
         };
 
         fastSyncAnchorData.nHeight = 3126937;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2103,12 +2103,14 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // cache size calculations
     int64_t nDbCacheArg = GetArg("-dbcache", nDefaultDbCache);
-    // During a full reindex or chainstate rebuild, a larger UTXO cache means far
-    // fewer leveldb flushes over the genesis..tip replay -- a sizable wall-clock win.
-    // Only raise the default (never override an explicit -dbcache), only on 64-bit
-    // (avoid OOM on 32-bit), and cap modestly to stay clear of low-RAM trouble.
-    if ((fReindex || fReindexChainState) && !mapArgs.count("-dbcache") && sizeof(void*) > 4) {
-        nDbCacheArg = std::max(nDbCacheArg, std::min<int64_t>(nMaxDbCache, 2048));
+    // Raise the default cache on 64-bit when the user hasn't set -dbcache: a larger
+    // cache means fewer leveldb flushes during sync and a faster, less "frozen-looking"
+    // cold block-index load on an already-synced chain. A full reindex / chainstate
+    // rebuild replays genesis..tip, so it benefits from an even larger cache. Never
+    // override an explicit -dbcache; 64-bit only (avoid OOM on 32-bit); capped modestly.
+    if (!mapArgs.count("-dbcache") && sizeof(void*) > 4) {
+        int64_t nDefault64 = (fReindex || fReindexChainState) ? 2048 : 1024;
+        nDbCacheArg = std::max(nDbCacheArg, std::min<int64_t>(nMaxDbCache, nDefault64));
     }
     int64_t nTotalCache = (nDbCacheArg << 20);
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -814,6 +814,14 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("chain",                 Params().NetworkIDString()));
     obj.push_back(Pair("blocks",                (int)chainActive.Height()));
     obj.push_back(Pair("headers",               pindexBestHeader ? pindexBestHeader->nHeight : -1));
+    // Best estimate of the network tip height. Headers sync ahead of blocks during
+    // IBD, so this is >= "blocks" while catching up and equals it once synced. GUI
+    // wallets use blocks/estimatedheight for an accurate, block-based progress bar
+    // (verificationprogress is a coarse tx-count heuristic, poor for a sync bar).
+    int nEstimatedHeight = chainActive.Height();
+    if (pindexBestHeader && pindexBestHeader->nHeight > nEstimatedHeight)
+        nEstimatedHeight = pindexBestHeader->nHeight;
+    obj.push_back(Pair("estimatedheight",       nEstimatedHeight));
     obj.push_back(Pair("bestblockhash",         chainActive.Tip()->GetBlockHash().GetHex()));
     obj.push_back(Pair("mediantime",            (int64_t)chainActive.Tip()->GetMedianTimePast()));
     obj.push_back(Pair("difficulty",            (double)GetNetworkDifficulty()));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -9,6 +9,7 @@
 #include "hash.h"
 #include "main.h"
 #include "pow.h"
+#include "ui_interface.h"
 #include "uint256.h"
 
 #include <stdint.h>
@@ -375,6 +376,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 
     pcursor->Seek(make_pair(DB_BLOCK_INDEX, uint256()));
 
+    int64_t nLoaded = 0;
+
     // Load mapBlockIndex
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
@@ -412,6 +415,16 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 
                 pcursor->Next();
+
+                // The block index holds millions of records; scanning it is the
+                // longest phase of an otherwise-synced startup. Emit a periodic
+                // progress message so neither the console nor a GUI looks frozen.
+                // InitMessage is wired to SetRPCWarmupStatus (init.cpp), so the
+                // climbing count also reaches GUI wallets polling over RPC during
+                // warmup. Trailing "..." matches the wallet's dot-animation. Purely
+                // cosmetic -- it does not change what is loaded.
+                if ((++nLoaded % 50000) == 0)
+                    uiInterface.InitMessage(strprintf(_("Loading block index %d..."), nLoaded));
             } else {
                 return error("LoadBlockIndex() : failed to read value");
             }


### PR DESCRIPTION
## GUI smoothness (part of v2.1.2-beta3)

Three daemon-side fixes that make the bundled GUI wallet (`zcl-qt-wallet`) feel smooth. **No wallet code changes needed** — the wallet already reads these values; it just needed correct data.

### 1. Sync stuck at ~96% → reaches 100% + "Connected"
`Checkpoints::GuessVerificationProgress` divides the chain's real cumulative tx count by the hardcoded `ChainTxData` estimate. The old `nTransactionsLastCheckpoint = 5,293,850` was a height-derived guess that **overshot** the real chain (~5.12M tx at the tip), so a fully-synced node stayed in the "below checkpoint" branch forever and `verificationprogress` capped at ~0.964 — shown by the wallet as a permanent "Syncing 96%". Reset `ChainTxData` to a **measured** reference (mainnet height 3,130,800: `nChainTx=5,121,107`, its block time, ~1138 tx/day). Synced nodes now report ~1.0. Cosmetic only — these fields feed `verificationprogress` alone, never consensus, validation, or the fast-sync anchor commitment.

### 2. `getblockchaininfo` emits `estimatedheight`
`max(blocks, bestheader)` — GUI wallets use `blocks/estimatedheight` for an accurate block-based progress bar during IBD (the wallet already had the code path, gated on this field being present).

### 3. Startup no longer looks frozen + loads faster
- `LoadBlockIndexGuts` scans millions of records with no progress callback, so the GUI splash sat frozen on "Loading block index…" for ~1 min. It now emits a periodic `InitMessage` (`"Loading block index N…"`), which is wired to `SetRPCWarmupStatus` (init.cpp), so GUI wallets polling over RPC during warmup see a live, climbing count.
- Default `-dbcache` raised to 1024 MiB on 64-bit when unset (2048 during reindex) for fewer leveldb flushes and a faster cold index load.

### Verification
- `test_bitcoin` **401/401**, clean build
- regtest: `estimatedheight` tracks block height; node starts/stops cleanly
- analytic: synced tip → ~100% via the formula with the new constants
- Bundled into the beta3 Linux AppImage + Windows GUI (wallet binary unchanged; only the bundled `zclassicd` differs)
