### PR TITLE
bootstrap: fast-sync datadirs stuck at a genesis-only chainstate ("syncing 0")

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -763,6 +763,90 @@ bool IsBootstrapFreshChainDatadir(const boost::filesystem::path& data_dir, std::
     return true;
 }
 
+// Returns true if the datadir carries chain data (so IsBootstrapFreshChainDatadir
+// is false) but that data is only a genesis-height chainstate — i.e. a node that
+// created its databases but never synced past genesis. This happens, for example,
+// when a previous bootstrap snapshot download was interrupted, or when a daemon
+// started once, initialized its DBs at genesis, found no peers (sparse DNS seeds)
+// and hung at 0 blocks. Such a datadir holds no real chain, so it is safe to back
+// up and fast-sync into. A datadir with a real (post-genesis) tip returns false
+// and must never be touched.
+bool IsGenesisOnlyChainDatadir(const boost::filesystem::path& data_dir, std::string& error)
+{
+    const boost::filesystem::path chainstate_dir = data_dir / "chainstate";
+    if (!boost::filesystem::exists(chainstate_dir)) {
+        // No chainstate to read a tip from. A blocks/-only datadir is an unusual
+        // partial state; treat it as real data and leave it alone.
+        return false;
+    }
+    try {
+        // Open the chainstate and read its best-block marker, then let the
+        // CCoinsViewDB destruct (releasing the leveldb lock) before the normal
+        // chainstate open later in init. Mirrors the serve-copy probe elsewhere
+        // in this file. We never write through this handle.
+        CCoinsViewDB probe(chainstate_dir, 1 << 23, false, false);
+        const uint256 best = probe.GetBestBlock();
+        if (best.IsNull())
+            return true; // chainstate initialized but no block connected yet
+        return best == Params().GenesisBlock().GetHash();
+    } catch (const std::exception& e) {
+        // A chainstate we cannot open/parse is not provably genesis-only; be
+        // conservative and treat it as real data so we never clobber a chain.
+        error = strprintf("could not read chainstate best block from %s: %s", chainstate_dir.string(), e.what());
+        return false;
+    }
+}
+
+// Move a genesis-only datadir's blocks/ and chainstate/ into a timestamped backup
+// directory so the datadir becomes "fresh" again and a bootstrap snapshot can be
+// imported into it. Mirrors the backup step in ImportBootstrapDatadir. wallet.dat,
+// peers.dat and configuration are left untouched. Reversible: the moved data
+// remains in the backup dir and can be restored by hand.
+bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, std::string& error)
+{
+    const boost::filesystem::path blocks_dir = data_dir / "blocks";
+    const boost::filesystem::path chainstate_dir = data_dir / "chainstate";
+    try {
+        const boost::filesystem::path backup =
+            data_dir / boost::filesystem::unique_path(strprintf("bootstrap-genesis-backup-%d-%%%%-%%%%-%%%%", GetTime()));
+        boost::filesystem::create_directories(backup);
+        if (boost::filesystem::exists(blocks_dir))
+            boost::filesystem::rename(blocks_dir, backup / "blocks");
+        if (boost::filesystem::exists(chainstate_dir))
+            boost::filesystem::rename(chainstate_dir, backup / "chainstate");
+        LogPrintf("Bootstrap: moved genesis-only chain data to %s\n", backup.string());
+        return true;
+    } catch (const boost::filesystem::filesystem_error& e) {
+        error = strprintf("could not back up genesis-only chain data: %s", e.what());
+        return false;
+    }
+}
+
+// Decide whether a bootstrap snapshot may be imported into data_dir, performing
+// the genesis-only backup as a side effect when applicable. Returns true if the
+// datadir is fresh (no chain data) or held only a genesis-height chainstate that
+// was successfully moved aside. Returns false (with error set) if the datadir
+// carries a real chain or the backup failed — the caller then skips bootstrap.
+bool BootstrapDatadirEligible(const boost::filesystem::path& data_dir, std::string& error)
+{
+    if (IsBootstrapFreshChainDatadir(data_dir, error))
+        return true;
+    // Not fresh. The only safe exception is a datadir that holds nothing but a
+    // genesis-height chainstate: back it up so the datadir is fresh again.
+    std::string genesis_err;
+    if (IsGenesisOnlyChainDatadir(data_dir, genesis_err)) {
+        std::string backup_err;
+        if (BackupGenesisOnlyChainData(data_dir, backup_err)) {
+            LogPrintf("Bootstrap: datadir held only a genesis-height chainstate; backed it up to fast-sync into a fresh datadir\n");
+            return true;
+        }
+        error = backup_err;
+    }
+    // error retains the IsBootstrapFreshChainDatadir reason (real chain data)
+    // unless the genesis-only backup was attempted and failed.
+    return false;
+}
+
 bool ImportBootstrapDatadir(const boost::filesystem::path& source_root, const boost::filesystem::path& data_dir, bool force_backup, std::string& error)
 {
     if (!BootstrapSnapshotPathsExist(source_root)) {

--- a/src/bootstrap.h
+++ b/src/bootstrap.h
@@ -45,6 +45,15 @@ static const int64_t BOOTSTRAP_SERVE_DEFAULT_THROTTLE_KBPS = 1024;              
 
 bool BootstrapSnapshotPathsExist(const boost::filesystem::path& root);
 bool IsBootstrapFreshChainDatadir(const boost::filesystem::path& data_dir, std::string& error);
+// True if the datadir holds only a genesis-height chainstate (initialized but
+// never synced past genesis); such a datadir carries no real chain.
+bool IsGenesisOnlyChainDatadir(const boost::filesystem::path& data_dir, std::string& error);
+// Move a genesis-only datadir's blocks/ and chainstate/ aside to a timestamped
+// backup so a bootstrap snapshot can be imported into the now-fresh datadir.
+bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, std::string& error);
+// True if a bootstrap snapshot may be imported into data_dir: fresh, or a
+// genesis-only datadir that was successfully backed up (side effect).
+bool BootstrapDatadirEligible(const boost::filesystem::path& data_dir, std::string& error);
 bool ImportBootstrapDatadir(const boost::filesystem::path& source_root,
                             const boost::filesystem::path& data_dir,
                             bool force_backup,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1977,9 +1977,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             if (!fTrustlessMode && !haveAnchor) {
                 if (explicit_peer)
                     return InitError(_("-bootstrappeer requires a compiled fast-sync anchor (or -bootstrapmode=trustless)"));
-            } else if (!IsBootstrapFreshChainDatadir(GetDataDir(), bootstrap_error)) {
-                // Datadir already has chain data: skip silently unless the user
-                // explicitly asked to bootstrap into it.
+            } else if (!BootstrapDatadirEligible(GetDataDir(), bootstrap_error)) {
+                // Datadir already has real chain data: skip silently unless the
+                // user explicitly asked to bootstrap into it. A datadir holding
+                // only a genesis-height chainstate (a node that initialized its
+                // DBs but never synced — e.g. a prior interrupted bootstrap that
+                // then fell back to peerless P2P sync and hung at 0 blocks) is
+                // backed up by BootstrapDatadirEligible and counts as eligible.
                 if (explicit_peer)
                     return InitError(bootstrap_error);
             } else {

--- a/src/test/bootstrap_snapshot_protocol_tests.cpp
+++ b/src/test/bootstrap_snapshot_protocol_tests.cpp
@@ -7,8 +7,10 @@
 #include "bootstrapvalidation.h"
 #include "chainparams.h"
 #include "checkpoints.h"
+#include "coins.h"
 #include "crypto/sha256.h"
 #include "main.h"
+#include "txdb.h"
 #include "net.h"
 #include "streams.h"
 #include "test/test_bitcoin.h"
@@ -1071,6 +1073,65 @@ BOOST_AUTO_TEST_CASE(bootstrap_fresh_chain_datadir_checks_chain_files)
     BOOST_CHECK(error.find("legacy block file") != std::string::npos);
 
     boost::filesystem::remove_all(root);
+}
+
+// Write a chainstate leveldb under data_dir/chainstate whose best block is
+// `tip`, then close it. Mirrors how the node persists its chain tip.
+static void WriteChainstateWithTip(const boost::filesystem::path& data_dir, const uint256& tip)
+{
+    CCoinsViewDB db(data_dir / "chainstate", 1 << 20, false, /*fWipe=*/true);
+    CCoinsViewCache cache(&db);
+    cache.SetBestBlock(tip);
+    BOOST_CHECK(cache.Flush());
+}
+
+// A datadir whose chainstate is still at the genesis block (a node that
+// initialized its DBs but never synced) is detected as genesis-only and is made
+// eligible for bootstrap by backing the stale DBs aside — while a datadir with a
+// real, post-genesis tip is left strictly untouched.
+BOOST_AUTO_TEST_CASE(bootstrap_genesis_only_datadir_is_eligible_real_chain_is_not)
+{
+    namespace fs = boost::filesystem;
+    std::string error;
+
+    // ---- genesis-only datadir ----
+    fs::path gen = fs::temp_directory_path() / fs::unique_path("zclassic-bootstrap-genonly-%%%%-%%%%-%%%%");
+    fs::create_directories(gen);
+    WriteChainstateWithTip(gen, Params().GenesisBlock().GetHash());
+    fs::create_directories(gen / "blocks");
+
+    BOOST_CHECK(!IsBootstrapFreshChainDatadir(gen, error)); // has chain data
+    BOOST_CHECK(IsGenesisOnlyChainDatadir(gen, error));      // ...but only genesis
+
+    // Eligible: the stale genesis DBs are moved to a timestamped backup, leaving
+    // the datadir fresh again.
+    BOOST_CHECK(BootstrapDatadirEligible(gen, error));
+    BOOST_CHECK(!fs::exists(gen / "blocks"));
+    BOOST_CHECK(!fs::exists(gen / "chainstate"));
+    BOOST_CHECK(IsBootstrapFreshChainDatadir(gen, error));
+    bool foundBackup = false;
+    for (fs::directory_iterator it(gen), end; it != end; ++it) {
+        if (it->path().filename().string().find("bootstrap-genesis-backup-") == 0 &&
+            fs::exists(it->path() / "chainstate"))
+            foundBackup = true;
+    }
+    BOOST_CHECK(foundBackup);
+
+    // ---- real (post-genesis) chain datadir: must never be clobbered ----
+    fs::path real = fs::temp_directory_path() / fs::unique_path("zclassic-bootstrap-real-%%%%-%%%%-%%%%");
+    fs::create_directories(real);
+    WriteChainstateWithTip(real, uint256S("0x00000000000000000000000000000000000000000000000000000000deadbeef"));
+    fs::create_directories(real / "blocks");
+
+    BOOST_CHECK(!IsBootstrapFreshChainDatadir(real, error));
+    BOOST_CHECK(!IsGenesisOnlyChainDatadir(real, error));
+    BOOST_CHECK(!BootstrapDatadirEligible(real, error));
+    // Untouched — no backup, blocks/ and chainstate/ still present.
+    BOOST_CHECK(fs::exists(real / "blocks"));
+    BOOST_CHECK(fs::exists(real / "chainstate"));
+
+    fs::remove_all(gen);
+    fs::remove_all(real);
 }
 
 BOOST_AUTO_TEST_CASE(bootstrap_import_datadir_refuses_existing_without_force)


### PR DESCRIPTION
## Problem

A freshly-installed wallet can get permanently stuck at **"syncing 0"** (0 blocks, 0 connections). Reproduced on macOS arm64 with the beta3 GUI bundle.

Root cause: the bootstrap fast-sync only runs into a **completely empty** datadir. The gate in `AppInit2` (`init.cpp`) is `IsBootstrapFreshChainDatadir()`, which reports a datadir as non-fresh if `blocks/` or `chainstate/` exists **at all** — even a genesis-only chainstate at height 0.

So once a node has started even once and initialized its DBs at genesis — e.g.:
- a previous snapshot download was interrupted, or
- a first start initialized the chainstate and then found no peers,

…the datadir is no longer "fresh", bootstrap is **skipped silently**, and it falls back to normal P2P sync. ZClassic's DNS seeds are effectively dead (measured: `1 addresses found from DNS seeds`, and that peer timed out), so the node sits at **0 connections / 0 blocks forever**. The GUI spawns its own daemon into exactly such a datadir, which is how this surfaces as "syncing 0".

The retry logic from #109 only helps *within* a single fresh-datadir start; it does not help across restarts of a now-non-fresh datadir.

## Fix

Treat a datadir whose chainstate **best block is still the genesis block** (or empty) as eligible for bootstrap:

1. `IsGenesisOnlyChainDatadir()` — opens the chainstate, reads `GetBestBlock()`; genesis (or null) ⇒ the datadir carries no real chain. (Mirrors the existing serve-copy probe pattern.)
2. `BackupGenesisOnlyChainData()` — moves the stale `blocks/` + `chainstate/` into a timestamped `bootstrap-genesis-backup-*` dir (reusing the `ImportBootstrapDatadir` backup pattern), so the datadir is fresh again. `wallet.dat` / `peers.dat` / config untouched; the move is reversible.
3. `BootstrapDatadirEligible()` — fresh **or** (genesis-only **and** successfully backed up). The `init.cpp` gate now calls this instead of the bare freshness check; the large bootstrap-run block is unchanged.

A datadir with a real, post-genesis tip returns `false` and is **left strictly untouched** — a synced chain is never clobbered.

## Testing

- **Live repro + fix (macOS arm64):** created a genesis-only datadir (daemon started with `-bootstrap=0`, tip `height=0`). With the fix, restart logs `datadir held only a genesis-height chainstate; backed it up…` and proceeds to download the snapshot (`Bootstrap: downloading snapshot … 0→2%`). The previously-stuck datadir now fast-syncs.
- **Unit test** `bootstrap_genesis_only_datadir_is_eligible_real_chain_is_not`: covers genesis-only (detected, backed up, eligible, datadir fresh afterward) **and** real-chain (best block ≠ genesis ⇒ not genesis-only, not eligible, `blocks/`+`chainstate/` untouched, no backup).
- Full `bootstrap_snapshot_protocol_tests` suite: **55/55 pass**.

## Tradeoff / note for reviewers

`IsGenesisOnlyChainDatadir` opens the chainstate to read the tip, so a **synced** node now does one extra (sequential, read-only) chainstate open at startup before the normal open. It's safe, but if startup cost is a concern it could be gated (e.g. skip the probe above a chainstate-size threshold, or only when `-bootstrap` is explicit). Happy to adjust.

Branch was cut from the beta3 commit (now merged to master); single-commit diff, merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)