### PR TITLE
bootstrap: harden genesis-only fast-sync (no data loss, no redundant chainstate open)

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -763,14 +763,41 @@ bool IsBootstrapFreshChainDatadir(const boost::filesystem::path& data_dir, std::
     return true;
 }
 
+// Sum of regular-file sizes under `dir`, short-circuiting as soon as the running
+// total exceeds `limit` (the returned value is then simply some number > limit;
+// its exact magnitude past the cap is irrelevant). Lets a tiny genesis-only
+// blocks//chainstate be told apart from a real multi-GB one with only a stat walk
+// — no database open. A missing dir counts as zero. Symlinked entries are not
+// recursed into (boost default); a stat error propagates to the caller's catch.
+static uint64_t DirBytesCappedAt(const boost::filesystem::path& dir, uint64_t limit)
+{
+    if (!boost::filesystem::exists(dir))
+        return 0;
+    uint64_t total = 0;
+    for (boost::filesystem::recursive_directory_iterator it(dir), end; it != end; ++it) {
+        if (boost::filesystem::is_regular_file(it->path())) {
+            total += (uint64_t)boost::filesystem::file_size(it->path());
+            if (total > limit)
+                return total;
+        }
+    }
+    return total;
+}
+
 // Returns true if the datadir carries chain data (so IsBootstrapFreshChainDatadir
 // is false) but that data is only a genesis-height chainstate — i.e. a node that
 // created its databases but never synced past genesis. This happens, for example,
 // when a previous bootstrap snapshot download was interrupted, or when a daemon
 // started once, initialized its DBs at genesis, found no peers (sparse DNS seeds)
 // and hung at 0 blocks. Such a datadir holds no real chain, so it is safe to back
-// up and fast-sync into. A datadir with a real (post-genesis) tip returns false
-// and must never be touched.
+// up and fast-sync into.
+//
+// CRITICAL: a datadir with any real chain data must return false and never be
+// touched. Because the backup moves BOTH blocks/ and chainstate/, "genesis-only"
+// is judged over BOTH: a large blocks/ means real downloaded blocks even if the
+// chainstate reads genesis or empty (e.g. an interrupted -reindex-chainstate
+// wipes the coins DB — best block null — while blocks/ keeps the full chain).
+// Either directory exceeding the threshold ⇒ not genesis-only.
 bool IsGenesisOnlyChainDatadir(const boost::filesystem::path& data_dir, std::string& error)
 {
     const boost::filesystem::path chainstate_dir = data_dir / "chainstate";
@@ -780,10 +807,27 @@ bool IsGenesisOnlyChainDatadir(const boost::filesystem::path& data_dir, std::str
         return false;
     }
     try {
-        // Open the chainstate and read its best-block marker, then let the
-        // CCoinsViewDB destruct (releasing the leveldb lock) before the normal
-        // chainstate open later in init. Mirrors the serve-copy probe elsewhere
-        // in this file. We never write through this handle.
+        // Cheap, read-only size gate first. A real synced (or interrupted-reindex)
+        // datadir is gigabytes; a genesis-only one (the interrupted-download /
+        // peerless-first-start case this targets) is a handful of small files plus
+        // the preallocated ~16 MiB genesis block file. Short-circuiting on size
+        // means a healthy node pays only a stat walk and never has to OPEN its live
+        // chainstate on every startup just to learn it is not genesis. The
+        // threshold sits far above any genesis-only datadir and far below any real
+        // one, so it can never produce a false "genesis-only": an over-threshold
+        // dir returns false here without the data ever being moved/deleted; the
+        // best-block probe below is reached only for genuinely tiny datadirs.
+        const uint64_t kGenesisOnlyMaxBytes = 64ULL * 1024 * 1024; // 64 MiB
+        if (DirBytesCappedAt(chainstate_dir, kGenesisOnlyMaxBytes) > kGenesisOnlyMaxBytes)
+            return false; // a real (or recoverable) chainstate
+        if (DirBytesCappedAt(data_dir / "blocks", kGenesisOnlyMaxBytes) > kGenesisOnlyMaxBytes)
+            return false; // real downloaded blocks present — never move/delete these
+        // Small chainstate AND small blocks/: open the chainstate and read its
+        // best-block marker. This is a WRITABLE leveldb open (it takes the LOCK and
+        // may rewrite CURRENT/MANIFEST on recovery), but it only runs for a tiny
+        // genesis-only datadir, never for a healthy synced node (gated out by size
+        // above). The handle is released when the CCoinsViewDB destructs, before
+        // the normal chainstate open later in init. Mirrors the serve-copy probe.
         CCoinsViewDB probe(chainstate_dir, 1 << 23, false, false);
         const uint256 best = probe.GetBestBlock();
         if (best.IsNull())
@@ -800,10 +844,13 @@ bool IsGenesisOnlyChainDatadir(const boost::filesystem::path& data_dir, std::str
 // Move a genesis-only datadir's blocks/ and chainstate/ into a timestamped backup
 // directory so the datadir becomes "fresh" again and a bootstrap snapshot can be
 // imported into it. Mirrors the backup step in ImportBootstrapDatadir. wallet.dat,
-// peers.dat and configuration are left untouched. Reversible: the moved data
-// remains in the backup dir and can be restored by hand.
-bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, std::string& error)
+// peers.dat and configuration are left untouched. On success outBackup is set to
+// the backup directory. If the subsequent bootstrap fails, the caller calls
+// RestoreGenesisOnlyChainData to move the data back, leaving the datadir exactly
+// as it was found (only genesis-only data is ever moved — see IsGenesisOnlyChainDatadir).
+bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, boost::filesystem::path& outBackup, std::string& error)
 {
+    outBackup.clear();
     const boost::filesystem::path blocks_dir = data_dir / "blocks";
     const boost::filesystem::path chainstate_dir = data_dir / "chainstate";
     try {
@@ -814,6 +861,7 @@ bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, std::st
             boost::filesystem::rename(blocks_dir, backup / "blocks");
         if (boost::filesystem::exists(chainstate_dir))
             boost::filesystem::rename(chainstate_dir, backup / "chainstate");
+        outBackup = backup;
         LogPrintf("Bootstrap: moved genesis-only chain data to %s\n", backup.string());
         return true;
     } catch (const boost::filesystem::filesystem_error& e) {
@@ -822,28 +870,63 @@ bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, std::st
     }
 }
 
+// Undo BackupGenesisOnlyChainData: move blocks/ and chainstate/ back from `backup`
+// into data_dir and remove the emptied backup directory, so a failed bootstrap
+// leaves the datadir exactly as it was found. Best-effort; only moves a directory
+// back if the datadir does not already have one (a successful bootstrap install
+// would have placed fresh blocks//chainstate, which must not be overwritten).
+bool RestoreGenesisOnlyChainData(const boost::filesystem::path& data_dir, const boost::filesystem::path& backup, std::string& error)
+{
+    try {
+        if (boost::filesystem::exists(backup / "blocks") && !boost::filesystem::exists(data_dir / "blocks"))
+            boost::filesystem::rename(backup / "blocks", data_dir / "blocks");
+        if (boost::filesystem::exists(backup / "chainstate") && !boost::filesystem::exists(data_dir / "chainstate"))
+            boost::filesystem::rename(backup / "chainstate", data_dir / "chainstate");
+        boost::filesystem::remove_all(backup);
+        LogPrintf("Bootstrap: restored genesis-only chain data from %s\n", backup.string());
+        return true;
+    } catch (const boost::filesystem::filesystem_error& e) {
+        error = strprintf("could not restore genesis-only chain data from %s: %s", backup.string(), e.what());
+        return false;
+    }
+}
+
 // Decide whether a bootstrap snapshot may be imported into data_dir, performing
 // the genesis-only backup as a side effect when applicable. Returns true if the
 // datadir is fresh (no chain data) or held only a genesis-height chainstate that
-// was successfully moved aside. Returns false (with error set) if the datadir
-// carries a real chain or the backup failed — the caller then skips bootstrap.
-bool BootstrapDatadirEligible(const boost::filesystem::path& data_dir, std::string& error)
+// was successfully moved aside; in the latter case outBackupDir is set to the
+// directory the stale DBs were moved to (so the caller can restore it if the
+// bootstrap then fails). Returns false (with error set) if the datadir carries a
+// real chain or the backup failed — the caller then skips bootstrap.
+bool BootstrapDatadirEligible(const boost::filesystem::path& data_dir, boost::filesystem::path& outBackupDir, std::string& error)
 {
+    outBackupDir.clear();
     if (IsBootstrapFreshChainDatadir(data_dir, error))
         return true;
     // Not fresh. The only safe exception is a datadir that holds nothing but a
     // genesis-height chainstate: back it up so the datadir is fresh again.
     std::string genesis_err;
     if (IsGenesisOnlyChainDatadir(data_dir, genesis_err)) {
+        boost::filesystem::path backup;
         std::string backup_err;
-        if (BackupGenesisOnlyChainData(data_dir, backup_err)) {
+        if (BackupGenesisOnlyChainData(data_dir, backup, backup_err)) {
+            // The backup moves only blocks/ + chainstate/. A genesis-only datadir
+            // never carries a top-level bootstrap.dat or legacy blkNNNNN.dat (the
+            // daemon does not create them); in the pathological case one is present
+            // BootstrapFromPeer's own up-front IsBootstrapFreshChainDatadir check
+            // fails fast (before any download) and the caller removes this backup.
+            outBackupDir = backup;
             LogPrintf("Bootstrap: datadir held only a genesis-height chainstate; backed it up to fast-sync into a fresh datadir\n");
             return true;
         }
         error = backup_err;
+        return false;
     }
-    // error retains the IsBootstrapFreshChainDatadir reason (real chain data)
-    // unless the genesis-only backup was attempted and failed.
+    // Not genesis-only: error retains the IsBootstrapFreshChainDatadir reason (real
+    // chain data). Prepend the chainstate-open failure if one occurred, so an
+    // explicit -bootstrappeer InitError shows why the genesis probe could not run.
+    if (!genesis_err.empty())
+        error = genesis_err + "; " + error;
     return false;
 }
 

--- a/src/bootstrap.h
+++ b/src/bootstrap.h
@@ -50,10 +50,17 @@ bool IsBootstrapFreshChainDatadir(const boost::filesystem::path& data_dir, std::
 bool IsGenesisOnlyChainDatadir(const boost::filesystem::path& data_dir, std::string& error);
 // Move a genesis-only datadir's blocks/ and chainstate/ aside to a timestamped
 // backup so a bootstrap snapshot can be imported into the now-fresh datadir.
-bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, std::string& error);
+// On success outBackup is set to the backup directory; the caller restores it
+// with RestoreGenesisOnlyChainData if the bootstrap subsequently fails.
+bool BackupGenesisOnlyChainData(const boost::filesystem::path& data_dir, boost::filesystem::path& outBackup, std::string& error);
+// Move blocks/ and chainstate/ back from a BackupGenesisOnlyChainData backup into
+// data_dir and remove the backup, undoing the move when a bootstrap attempt fails.
+bool RestoreGenesisOnlyChainData(const boost::filesystem::path& data_dir, const boost::filesystem::path& backup, std::string& error);
 // True if a bootstrap snapshot may be imported into data_dir: fresh, or a
-// genesis-only datadir that was successfully backed up (side effect).
-bool BootstrapDatadirEligible(const boost::filesystem::path& data_dir, std::string& error);
+// genesis-only datadir that was successfully backed up (side effect). When a
+// backup was made, outBackupDir names it so the caller can remove it if the
+// bootstrap subsequently fails.
+bool BootstrapDatadirEligible(const boost::filesystem::path& data_dir, boost::filesystem::path& outBackupDir, std::string& error);
 bool ImportBootstrapDatadir(const boost::filesystem::path& source_root,
                             const boost::filesystem::path& data_dir,
                             bool force_backup,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1947,6 +1947,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // failure fatal; the automatic path is best-effort and falls back to normal
     // peer-to-peer sync if no bootstrap peer is reachable.
     bool bootstrap_snapshot_ran = false;
+    // If a genesis-only datadir is moved aside to make room for a fast-sync, this
+    // names the backup directory so we can restore it if the bootstrap fails.
+    boost::filesystem::path genesisBackupDir;
     {
         const bool explicit_peer = mapArgs.count("-bootstrappeer");
         const bool enabled = GetBoolArg("-bootstrap", true) && !GetBootstrapPeerList().empty();
@@ -1977,7 +1980,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             if (!fTrustlessMode && !haveAnchor) {
                 if (explicit_peer)
                     return InitError(_("-bootstrappeer requires a compiled fast-sync anchor (or -bootstrapmode=trustless)"));
-            } else if (!BootstrapDatadirEligible(GetDataDir(), bootstrap_error)) {
+            } else if (!BootstrapDatadirEligible(GetDataDir(), genesisBackupDir, bootstrap_error)) {
                 // Datadir already has real chain data: skip silently unless the
                 // user explicitly asked to bootstrap into it. A datadir holding
                 // only a genesis-height chainstate (a node that initialized its
@@ -2040,6 +2043,20 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     }
                 }
                 if (!bootstrap_snapshot_ran) {
+                    // No snapshot was imported this start. If we moved a genesis-only
+                    // datadir aside to attempt it, move it back so the datadir is left
+                    // exactly as it was found (and no backup dir accumulates). Only a
+                    // genesis-only datadir is ever moved, but restoring rather than
+                    // deleting guarantees we can never destroy chain data even if that
+                    // classification were ever wrong. Done before the explicit-peer
+                    // InitError too, so a failed -bootstrappeer also leaves no mess.
+                    if (!genesisBackupDir.empty()) {
+                        std::string restore_err;
+                        if (!RestoreGenesisOnlyChainData(GetDataDir(), genesisBackupDir, restore_err))
+                            LogPrintf("Bootstrap: could not restore genesis chain data: %s (backup retained at %s)\n",
+                                      restore_err, genesisBackupDir.string());
+                        genesisBackupDir.clear();
+                    }
                     if (explicit_peer)
                         return InitError(bootstrap_error);
                     LogPrintf("Bootstrap snapshot unavailable; continuing with normal peer-to-peer sync: %s\n", bootstrap_error);

--- a/src/test/bootstrap_snapshot_protocol_tests.cpp
+++ b/src/test/bootstrap_snapshot_protocol_tests.cpp
@@ -1103,19 +1103,15 @@ BOOST_AUTO_TEST_CASE(bootstrap_genesis_only_datadir_is_eligible_real_chain_is_no
     BOOST_CHECK(!IsBootstrapFreshChainDatadir(gen, error)); // has chain data
     BOOST_CHECK(IsGenesisOnlyChainDatadir(gen, error));      // ...but only genesis
 
-    // Eligible: the stale genesis DBs are moved to a timestamped backup, leaving
-    // the datadir fresh again.
-    BOOST_CHECK(BootstrapDatadirEligible(gen, error));
+    // Eligible: the stale genesis DBs are moved to a timestamped backup (reported
+    // via the out-param), leaving the datadir fresh again.
+    fs::path genBackup;
+    BOOST_CHECK(BootstrapDatadirEligible(gen, genBackup, error));
+    BOOST_CHECK(!genBackup.empty());
+    BOOST_CHECK(fs::exists(genBackup / "chainstate"));
     BOOST_CHECK(!fs::exists(gen / "blocks"));
     BOOST_CHECK(!fs::exists(gen / "chainstate"));
     BOOST_CHECK(IsBootstrapFreshChainDatadir(gen, error));
-    bool foundBackup = false;
-    for (fs::directory_iterator it(gen), end; it != end; ++it) {
-        if (it->path().filename().string().find("bootstrap-genesis-backup-") == 0 &&
-            fs::exists(it->path() / "chainstate"))
-            foundBackup = true;
-    }
-    BOOST_CHECK(foundBackup);
 
     // ---- real (post-genesis) chain datadir: must never be clobbered ----
     fs::path real = fs::temp_directory_path() / fs::unique_path("zclassic-bootstrap-real-%%%%-%%%%-%%%%");
@@ -1125,13 +1121,54 @@ BOOST_AUTO_TEST_CASE(bootstrap_genesis_only_datadir_is_eligible_real_chain_is_no
 
     BOOST_CHECK(!IsBootstrapFreshChainDatadir(real, error));
     BOOST_CHECK(!IsGenesisOnlyChainDatadir(real, error));
-    BOOST_CHECK(!BootstrapDatadirEligible(real, error));
+    fs::path realBackup;
+    BOOST_CHECK(!BootstrapDatadirEligible(real, realBackup, error));
+    BOOST_CHECK(realBackup.empty());                    // nothing was moved
     // Untouched — no backup, blocks/ and chainstate/ still present.
     BOOST_CHECK(fs::exists(real / "blocks"));
     BOOST_CHECK(fs::exists(real / "chainstate"));
 
+    // ---- size gate: a genesis-tip chainstate padded past the threshold is
+    //      classified as a real chain WITHOUT opening leveldb (the cheap stat
+    //      walk short-circuits, so a synced node never re-opens its live DB). ----
+    fs::path big = fs::temp_directory_path() / fs::unique_path("zclassic-bootstrap-big-%%%%-%%%%-%%%%");
+    fs::create_directories(big);
+    WriteChainstateWithTip(big, Params().GenesisBlock().GetHash()); // tip == genesis
+    {
+        // Sparse 80 MiB file (> the 64 MiB gate) without writing 80 MiB of data.
+        boost::filesystem::ofstream f(big / "chainstate" / "fat.ldb", std::ios::binary);
+        f.seekp((std::streamoff)(80ULL * 1024 * 1024));
+        f.put('\0');
+    }
+    // Best block is genesis, but the dir is too large to be genesis-only.
+    BOOST_CHECK(!IsGenesisOnlyChainDatadir(big, error));
+
+    // ---- DATA-LOSS GUARD: genesis-tip chainstate but a real, large blocks/
+    //      (e.g. an interrupted -reindex-chainstate: coins DB wiped to genesis
+    //      while blocks/ keeps the full downloaded chain). Must NOT be treated as
+    //      genesis-only, must NOT be eligible, and the real blocks must be left
+    //      strictly in place — never moved aside or deleted. ----
+    fs::path rblocks = fs::temp_directory_path() / fs::unique_path("zclassic-bootstrap-rblocks-%%%%-%%%%-%%%%");
+    fs::create_directories(rblocks);
+    WriteChainstateWithTip(rblocks, Params().GenesisBlock().GetHash()); // chainstate at genesis
+    fs::create_directories(rblocks / "blocks");
+    {
+        // Sparse 80 MiB "blkNNNNN.dat" standing in for a real downloaded chain.
+        boost::filesystem::ofstream f(rblocks / "blocks" / "blk00000.dat", std::ios::binary);
+        f.seekp((std::streamoff)(80ULL * 1024 * 1024));
+        f.put('\0');
+    }
+    BOOST_CHECK(!IsGenesisOnlyChainDatadir(rblocks, error));   // real blocks => not genesis-only
+    fs::path rblocksBackup;
+    BOOST_CHECK(!BootstrapDatadirEligible(rblocks, rblocksBackup, error));
+    BOOST_CHECK(rblocksBackup.empty());                        // nothing moved
+    BOOST_CHECK(fs::exists(rblocks / "blocks" / "blk00000.dat")); // real blocks untouched
+    BOOST_CHECK(fs::exists(rblocks / "chainstate"));
+
     fs::remove_all(gen);
     fs::remove_all(real);
+    fs::remove_all(big);
+    fs::remove_all(rblocks);
 }
 
 BOOST_AUTO_TEST_CASE(bootstrap_import_datadir_refuses_existing_without_force)


### PR DESCRIPTION
Follow-up to #112 (merged). After #112 landed I ran a multi-agent robustness audit + adversarial review over the genesis-only self-heal and surrounding startup path. The peerless-node / dead-seed pin those surfaced is already fixed by #113 (pin on every start, second bootstrap peer, populated seeds) — this PR is the **two remaining issues #113 did not touch**, both in the genesis-only backup path.

## 1. Never destroy or shelve real chain data (the important one)

#112 judged "genesis-only" from the **chainstate alone**, but `BackupGenesisOnlyChainData` moves **both** `blocks/` and `chainstate/`. So a datadir with a genesis/empty chainstate next to a full multi-GB `blocks/` was misclassified and its real blocks moved aside.

This is reachable on a **supported workflow**: an interrupted `-reindex-chainstate` wipes the coins DB (best block reads *null*) while `blocks/` keeps the entire downloaded chain. A plain restart then has `conflicts == false`, bootstrap enabled, and the real chain gets moved into a backup.

Fixes:
- **Blocks-aware classification:** `IsGenesisOnlyChainDatadir` now treats a `chainstate/` **or** `blocks/` over 64 MiB as a real chain and returns false — the data is never moved. (Covers the null-best-block reindex case too.)
- **Restore, don't delete, on failure:** a failed bootstrap now calls the new `RestoreGenesisOnlyChainData` to move `blocks/`+`chainstate/` back and drop the backup, so an attempt leaves the datadir **exactly as it was found**. No path ever deletes user chain data.

## 2. Don't reopen a synced node's live chainstate on every boot

The genesis probe opened the chainstate leveldb (writable — takes the LOCK, may rewrite CURRENT/MANIFEST on recovery) on **every** startup, just to learn a synced node isn't at genesis. It's now gated behind a cheap stat-walk: a chainstate/blocks over 64 MiB short-circuits with no DB open.

## Testing
- Rebuilt-daemon live runs: genuine genesis-only (16 MiB `blocks/`) still self-heals and fast-syncs; a genesis-chainstate + large `blocks/` datadir is left **untouched** (no move, no backup, bootstrap skipped) while still syncing via P2P.
- Unit test extended with the size gate and a real-blocks **data-loss guard** case; `bootstrap_snapshot_protocol_tests` 55/55.

Single commit, based on current master (post-#112/#113), merges cleanly. Note: this does **not** re-touch the peer-pin gate — #113 owns that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)