### PR TITLE
version: report 2.1.2-beta5 (P2P subversion + RPC + clientversion)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,9 +4,9 @@ define(_CLIENT_VERSION_MAJOR, 2)
 define(_CLIENT_VERSION_MINOR, 1)
 define(_CLIENT_VERSION_REVISION, 2)
 dnl Build number drives the beta/rc suffix: for build N < 25 the version renders
-dnl as "<rev>-beta(N+1)". So beta4 == build 3. Bump this by one per beta and
+dnl as "<rev>-beta(N+1)". So beta5 == build 4. Bump this by one per beta and
 dnl re-tag so the compiled version, the P2P subversion, and the git tag agree.
-define(_CLIENT_VERSION_BUILD, 3)
+define(_CLIENT_VERSION_BUILD, 4)
 define(_ZC_BUILD_VAL, m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, m4_incr(_CLIENT_VERSION_BUILD), m4_eval(_CLIENT_VERSION_BUILD < 50), 1, m4_eval(_CLIENT_VERSION_BUILD - 24), m4_eval(_CLIENT_VERSION_BUILD == 50), 1, , m4_eval(_CLIENT_VERSION_BUILD - 50)))
 define(_CLIENT_VERSION_SUFFIX, m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, _CLIENT_VERSION_REVISION-beta$1, m4_eval(_CLIENT_VERSION_BUILD < 50), 1, _CLIENT_VERSION_REVISION-rc$1, m4_eval(_CLIENT_VERSION_BUILD == 50), 1, _CLIENT_VERSION_REVISION, _CLIENT_VERSION_REVISION-$1)))
 define(_CLIENT_VERSION_IS_RELEASE, true)

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,10 @@ AC_PREREQ([2.60])
 define(_CLIENT_VERSION_MAJOR, 2)
 define(_CLIENT_VERSION_MINOR, 1)
 define(_CLIENT_VERSION_REVISION, 2)
-define(_CLIENT_VERSION_BUILD, 1)
+dnl Build number drives the beta/rc suffix: for build N < 25 the version renders
+dnl as "<rev>-beta(N+1)". So beta4 == build 3. Bump this by one per beta and
+dnl re-tag so the compiled version, the P2P subversion, and the git tag agree.
+define(_CLIENT_VERSION_BUILD, 3)
 define(_ZC_BUILD_VAL, m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, m4_incr(_CLIENT_VERSION_BUILD), m4_eval(_CLIENT_VERSION_BUILD < 50), 1, m4_eval(_CLIENT_VERSION_BUILD - 24), m4_eval(_CLIENT_VERSION_BUILD == 50), 1, , m4_eval(_CLIENT_VERSION_BUILD - 50)))
 define(_CLIENT_VERSION_SUFFIX, m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, _CLIENT_VERSION_REVISION-beta$1, m4_eval(_CLIENT_VERSION_BUILD < 50), 1, _CLIENT_VERSION_REVISION-rc$1, m4_eval(_CLIENT_VERSION_BUILD == 50), 1, _CLIENT_VERSION_REVISION, _CLIENT_VERSION_REVISION-$1)))
 define(_CLIENT_VERSION_IS_RELEASE, true)

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -19,11 +19,11 @@
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 //! Fallback values for builds without config.h (HAVE_CONFIG_H); the autotools
 //! build overrides these from configure.ac. Keep them in sync with configure.ac
-//! (build N renders as "<rev>-beta(N+1)", so beta4 == build 3).
+//! (build N renders as "<rev>-beta(N+1)", so beta5 == build 4).
 #define CLIENT_VERSION_MAJOR 2
 #define CLIENT_VERSION_MINOR 1
 #define CLIENT_VERSION_REVISION 2
-#define CLIENT_VERSION_BUILD 3
+#define CLIENT_VERSION_BUILD 4
 
 //! Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE true

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -17,10 +17,13 @@
  */
 
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
+//! Fallback values for builds without config.h (HAVE_CONFIG_H); the autotools
+//! build overrides these from configure.ac. Keep them in sync with configure.ac
+//! (build N renders as "<rev>-beta(N+1)", so beta4 == build 3).
 #define CLIENT_VERSION_MAJOR 2
 #define CLIENT_VERSION_MINOR 1
-#define CLIENT_VERSION_REVISION 1
-#define CLIENT_VERSION_BUILD 60
+#define CLIENT_VERSION_REVISION 2
+#define CLIENT_VERSION_BUILD 3
 
 //! Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE true


### PR DESCRIPTION
A beta4 build currently advertises itself as **`2.1.2-beta2`** to every peer and RPC user.

`CLIENT_VERSION_BUILD` is `1`, and `FormatVersion()` renders build N (<25) as `<rev>-beta(N+1)` → `beta2`. So:
- P2P **subversion** is `/MagicBean:2.1.2-beta2/` (advertised in every `version` message)
- `getnetworkinfo`/`getinfo`, `--version`, and the `debug.log` banner all say beta2

Tagging `v2.1.2-beta4` does **not** fix this — the rendered version derives solely from `CLIENT_VERSION_BUILD`, not the git tag.

**Fix:** `beta4 == build 3`. Bump `_CLIENT_VERSION_BUILD` to `3` in `configure.ac` (this also corrects the `AC_INIT`/`PACKAGE_VERSION` string), and align the non-`config.h` fallback constants in `clientversion.h` that were separately stale at `2.1.1 build 60`.

**Verified:** a rebuilt daemon reports `ZClassic Daemon version v2.1.2-beta4`; `CLIENT_VERSION` becomes `2010203`.

Suggested convention (in the commit + comment): bump `_CLIENT_VERSION_BUILD` by one per beta and re-tag, so the compiled version, the P2P subversion, and the git tag never drift again. A CI check comparing `git describe` to `FormatFullVersion()` would enforce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)