### PR TITLE
bootstrap: fix SIGBUS in snapshot hash verify (1 MiB stack buffer on small worker-thread stacks)

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -3134,13 +3134,20 @@ static bool HashBootstrapSnapshotFile(const boost::filesystem::path& path, uint2
     }
 
     CSHA256 hasher;
-    unsigned char buffer[1024 * 1024];
+    // The hash buffer MUST be heap-allocated, not on the stack. This function runs on
+    // boost worker threads from the parallel snapshot downloader, whose default stack
+    // is small (512 KiB on macOS), so a 1 MiB on-stack buffer overruns the guard page
+    // and SIGBUSes (EXC_BAD_ACCESS, "thread stack size exceeded") mid bootstrap verify.
+    // Heap, same 1 MiB chunk -> no throughput change. (Fix surfaced by the macOS build;
+    // also at risk on Windows, whose default thread stack is 1 MiB.)
+    const size_t kChunk = 1024 * 1024;
+    std::vector<unsigned char> buffer(kChunk);
     while (true) {
-        size_t nRead = fread(buffer, 1, sizeof(buffer), file);
+        size_t nRead = fread(buffer.data(), 1, buffer.size(), file);
         if (nRead > 0) {
-            hasher.Write(buffer, nRead);
+            hasher.Write(buffer.data(), nRead);
         }
-        if (nRead < sizeof(buffer)) {
+        if (nRead < buffer.size()) {
             if (ferror(file)) {
                 error = strprintf("error reading bootstrap snapshot file: %s", path.string());
                 fclose(file);


### PR DESCRIPTION
## What

`HashBootstrapSnapshotFile` allocated its 1 MiB read buffer **on the stack**. That function runs on the parallel snapshot downloader's **boost worker threads**, whose default stack is small — **512 KiB on macOS**, ~1 MiB on Windows. The on-stack buffer overran the guard page and the daemon took a **SIGBUS / `EXC_BAD_ACCESS` ("thread stack size exceeded")** a few minutes into a fresh snapshot download, in the verify path (`VerifyBootstrapDownloadedFile`).

Linux's 8 MiB default thread stack masked the bug entirely; macOS hits it reliably and Windows is at risk.

## Fix

Move the buffer to the heap (`std::vector<unsigned char>`, same 1 MiB chunk). Hashing is byte-identical and there's no throughput change — only the allocation site moved from stack to heap.

```
src/bootstrap.cpp | 11 insertions(+), 4 deletions(-)
```

## Risk

Minimal. Same chunk size, same `CSHA256` streaming, same result — only stack→heap. No consensus, wire-format, or on-disk-format change.

## Provenance / validation

- **Found and first diagnosed by the macOS builder** while bringing up the arm64 `.dmg` (crash repro'd minutes into a fresh snapshot download).
- This fix is already baked into the **v2.1.2-beta5** Linux + Windows single-file pre-release binaries, and the macOS builder confirmed it via a multi-minute fresh-download soak with no crash.

This is a focused hotfix; the other beta5 daemon changes (self-heal / never-stuck / peer-discovery hardening, static-libgomp build option) are kept separate for their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
