### PR TITLE
beta7: crash-safety — graceful DB-flush failure + ThreadImport exception guard

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -664,6 +664,7 @@ void CleanupBlockRevFiles()
 void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
 {
     RenameThread("zcl-loadblk");
+    try {
     // -reindex
     if (fReindex) {
         CImportingNow imp;
@@ -716,6 +717,9 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     if (GetBoolArg("-stopafterblockimport", false)) {
         LogPrintf("Stopping after block import\n");
         StartShutdown();
+    }
+    } catch (const std::exception& e) {
+        LogPrintf("%s: failed: %s\n", __func__, e.what());
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2998,7 +2998,8 @@ bool static DisconnectTip(CValidationState &state, bool fBare = false) {
         CCoinsViewCache view(pcoinsTip);
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK)
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
-        assert(view.Flush());
+        if (!view.Flush())
+            return AbortNode(state, "Failed to write to coin database");
     }
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     uint256 sproutAnchorAfterDisconnect = pcoinsTip->GetBestAnchor(SPROUT);
@@ -3409,7 +3410,8 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
         mapBlockSource.erase(pindexNew->GetBlockHash());
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint("bench", "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);
-        assert(view.Flush());
+        if (!view.Flush())
+            return AbortNode(state, "Failed to write to coin database");
     }
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);


### PR DESCRIPTION
## What

Two NON-CONSENSUS robustness fixes that turn process-killing crashes into graceful handling.

### 1. Graceful coin-DB flush failure (`src/main.cpp`)
In `DisconnectTip()` and `ConnectTip()`, `assert(view.Flush());` aborted the process (and was a no-op in `-DNDEBUG` release builds) when the chainstate write failed. Replaced each with a graceful return that follows the existing error path:
```cpp
if (!view.Flush())
    return AbortNode(state, "Failed to write to coin database");
```
Both call sites have a `CValidationState& state` param, and `AbortNode(state, ...)` is already used throughout these functions (and with this exact message at the `FlushStateToDisk` site), so the daemon now shuts down cleanly with a clear error instead of `assert`-aborting / silently skipping the check.

### 2. `ThreadImport` exception guard (`src/init.cpp`)
`ThreadImport` (reindex / `LoadExternalBlockFile` / bootstrap.dat / `-loadblock`) is launched directly via `boost::bind(&ThreadImport, ...)`, NOT through `TraceThread`, so it is the one worker thread with no surrounding try/catch — an uncaught `std::exception` would `std::terminate` the whole process. Wrapped the body in:
```cpp
try { ... } catch (const std::exception& e) { LogPrintf("%s: failed: %s\n", __func__, e.what()); }
```
Success path behavior is identical; this only catches what would otherwise crash the node. Mirrors the existing `catch (const std::exception& e)` style already used elsewhere in `init.cpp`.

## Why
Audit-verified: both are pre-existing crash/abort hazards on I/O or import failure. The fixes only convert a hard process kill into a logged, graceful node shutdown (DB flush) or a logged thread exit (import).

## Files touched
- `src/main.cpp` — `DisconnectTip()`, `ConnectTip()`
- `src/init.cpp` — `ThreadImport()`

## Consensus impact: none
No change to block/tx validation results, PoW/Equihash, the script interpreter, hashed/signed bytes, chainparams, or activation heights — only failure-path handling (graceful abort vs. assert; catching an otherwise-fatal exception).

DRAFT: pending maintainer integration build + gtest.