### PR TITLE
beta7: P2P DoS hardening — blocklocator bound, mempool rate-limit, getdata cap

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6486,6 +6486,12 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         if ((fDebug && vInv.size() > 0) || (vInv.size() == 1))
             LogPrint("net", "received getdata for: %s peer=%d\n", vInv[0].ToString(), pfrom->id);
 
+        if (pfrom->vRecvGetData.size() + vInv.size() > 100000) {
+            Misbehaving(pfrom->GetId(), 20);
+            pfrom->fDisconnect = true;
+            return true;
+        }
+
         pfrom->vRecvGetData.insert(pfrom->vRecvGetData.end(), vInv.begin(), vInv.end());
         ProcessGetData(pfrom);
     }
@@ -6496,6 +6502,11 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
+
+        if (locator.vHave.size() > 64) {
+            Misbehaving(pfrom->GetId(), 20);
+            return true;
+        }
 
         LOCK(cs_main);
 
@@ -6540,6 +6551,11 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
+
+        if (locator.vHave.size() > 64) {
+            Misbehaving(pfrom->GetId(), 20);
+            return true;
+        }
 
         LOCK(cs_main);
 
@@ -6821,6 +6837,11 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
     else if (strCommand == "mempool")
     {
+        if (pfrom->fSentMempool) {
+            LogPrint("net", "Ignoring repeated \"mempool\" from peer=%d\n", pfrom->id);
+            return true;
+        }
+
         int currentHeight = GetHeight();
 
         LOCK2(cs_main, pfrom->cs_filter);
@@ -6848,6 +6869,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         }
         if (vInv.size() > 0)
             pfrom->PushMessage("inv", vInv);
+        pfrom->fSentMempool = true;
     }
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2102,6 +2102,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     fGetAddr = false;
     fRelayTxes = false;
     fSentAddr = false;
+    fSentMempool = false;
     fBootstrapManifestSent = false;
     fBootstrapParamManifestSent = false;
     pfilter = new CBloomFilter();

--- a/src/net.h
+++ b/src/net.h
@@ -287,6 +287,7 @@ public:
     //    until it has initialized its bloom filter.
     bool fRelayTxes;
     bool fSentAddr;
+    bool fSentMempool;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
     CBloomFilter* pfilter;


### PR DESCRIPTION
## What

Three audit-verified, NON-CONSENSUS P2P denial-of-service mitigations for beta7:

1. **Bound `CBlockLocator.vHave`** in the `getblocks` and `getheaders` handlers. Right after the locator is deserialized, reject and `Misbehaving(..., 20)` any locator with more than 64 entries. Legitimate locators are ~32 entries; an unbounded `vHave` lets a peer force expensive `FindForkInGlobalIndex` scans.

2. **Rate-limit the `mempool` command** (mirrors the existing `getaddr`/`fSentAddr` pattern). New `bool fSentMempool` on `CNode` (default false); the `mempool` handler now ignores repeated requests and only services one full mempool dump per connection, preventing repeated full-mempool scan/relay floods.

3. **Cap `vRecvGetData` growth** in the `getdata` handler. Before appending a received inv vector, if the pending queue would exceed 100000 entries, `Misbehaving(..., 20)`, set `fDisconnect`, and return — preventing unbounded per-peer memory growth from a slow/abusive `getdata` flood.

## Why

Audit-verified hardening of P2P message handling against cheap-to-send, expensive-to-process requests. Each guard only rejects input that could never come from a well-behaved peer.

## Files touched

- `src/main.cpp` — locator bound (getblocks + getheaders), mempool rate-limit, getdata cap
- `src/net.h` — `bool fSentMempool;` on `CNode`
- `src/net.cpp` — initialize `fSentMempool = false;` in the `CNode` constructor

## Consensus impact

**None** — these only touch P2P message handling (DoS guards / peer-misbehavior scoring / connection management) and reject input that could never be part of a valid request; no change to block/tx validation, PoW, script, hashed/signed bytes, chainparams, or activation heights.

## Status

DRAFT: pending maintainer integration build + gtest.