### PR TITLE
beta7: memory-safety — prevector capacity overflow guard + stream read size guard

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -172,10 +172,17 @@ private:
                 /* FIXME: Because malloc/realloc here won't call new_handler if allocation fails, assert
                     success. These should instead use an allocator or new/delete so that handlers
                     are called as necessary, but performance would be slightly degraded by doing so. */
+                // Guard against sizeof(T)*new_capacity overflowing size_t (would wrap to a
+                // small allocation followed by an out-of-bounds write). Compared in size_t
+                // to match the multiplication below; only rejects sizes that can never
+                // represent a valid object.
+                if ((size_t)new_capacity > SIZE_MAX / sizeof(T)) { new_handler_terminate(); }
                 _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
                 if (!_union.indirect) { new_handler_terminate(); }
                 _union.capacity = new_capacity;
             } else {
+                // Guard against sizeof(T)*new_capacity overflowing size_t (see above).
+                if ((size_t)new_capacity > SIZE_MAX / sizeof(T)) { new_handler_terminate(); }
                 char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
                 if (!new_indirect) { new_handler_terminate(); }
                 T* src = direct_ptr(0);

--- a/src/streams.h
+++ b/src/streams.h
@@ -281,6 +281,15 @@ public:
             throw std::ios_base::failure("CBaseDataStream::read(): cannot read from null pointer");
         }
 
+        // Bounds-check in full-width size_t before the (unsigned int) math below, which
+        // would otherwise truncate nReadPos + nSize on 64-bit and could wrap past the
+        // buffer. (vch.size() - nReadPos) is safe: nReadPos <= vch.size() is an invariant.
+        // This only rejects reads that already run past the end of data; valid reads are
+        // unaffected and still take the existing path below.
+        if (nSize > vch.size() - nReadPos) {
+            throw std::ios_base::failure("CBaseDataStream::read(): end of data");
+        }
+
         // Read from the beginning of the buffer
         unsigned int nReadPosNext = nReadPos + nSize;
         if (nReadPosNext >= vch.size())


### PR DESCRIPTION
## What

Two narrow, non-consensus memory-safety guards in serialization-adjacent code. Both reject **only** inputs that can never represent a valid object (a wrapped/overflowing size); valid data is unaffected.

### 1. prevector capacity overflow (`src/prevector.h`)
In `change_capacity()`, the indirect (re)allocation computes `((size_t)sizeof(T)) * new_capacity`. A wrapped/overflowing `new_capacity` would silently wrap to a small allocation followed by an out-of-bounds write. Added, before **both** the `realloc` and `malloc` sites:

```cpp
if ((size_t)new_capacity > SIZE_MAX / sizeof(T)) { new_handler_terminate(); }
```

Uses the file's existing failure idiom (`new_handler_terminate()`, the same `[[noreturn]]` handler the adjacent allocation-failure checks call). Compared in full-width `size_t` to exactly match the multiplication below it.

### 2. Stream read size guard (`src/streams.h`)
`CBaseDataStream::read(char* pch, size_t nSize)` computed `unsigned int nReadPosNext = nReadPos + nSize`, truncating `nSize` (a 64-bit `size_t`) into a 32-bit `unsigned int` (`nReadPos`'s type). A large `nSize` could truncate past the buffer check. Added a full-width `size_t` bounds check at the top that throws the **existing** end-of-data exception before any narrowing math runs:

```cpp
if (nSize > vch.size() - nReadPos) {
    throw std::ios_base::failure("CBaseDataStream::read(): end of data");
}
```

`vch.size() - nReadPos` is safe (`nReadPos <= vch.size()` is a class invariant). Chose an explicit bounds check over widening the `nReadPos` member type — lower risk, minimal diff. Same semantics for every valid read (including full-to-EOF reads, which still take the existing buffer-clear branch).

## Why

Audit-verified hardening of input-deserialization paths against integer overflow / truncation that could lead to OOB memory access on malformed/hostile P2P or RPC input.

## Files touched
- `src/prevector.h`
- `src/streams.h`

## Consensus impact: none
No change to block/tx validation results, PoW/Equihash, the script interpreter, bytes hashed/signed, chainparams, or activation heights. The guards trigger only on sizes that can never represent a valid object, so they cannot alter the accept/reject outcome of any valid data — the existing serialization gtests exercise realistic sizes and are unaffected.

**DRAFT: pending maintainer integration build + gtest.**