### PR TITLE
beta7: RPC/HTTP hardening — timing-safe auth, JSON depth limit, batch cap, body-size cap

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -39,6 +39,11 @@
 #include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 
+/** Maximum size (in bytes) of an HTTP request body we will accept. The RPC
+ * interface never needs anywhere near MAX_SIZE; cap it to bound memory use
+ * from a single connection. */
+static const size_t MAX_HTTP_REQUEST_SIZE = 10 * 1024 * 1024;
+
 /** HTTP request work item */
 class HTTPWorkItem : public HTTPClosure
 {
@@ -419,7 +424,7 @@ bool InitHTTPServer()
     }
 
     evhttp_set_timeout(http, GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT));
-    evhttp_set_max_body_size(http, MAX_SIZE);
+    evhttp_set_max_body_size(http, MAX_HTTP_REQUEST_SIZE);
     evhttp_set_gencb(http, http_request_cb, NULL);
 
     if (!HTTPBindAddresses(http)) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -435,8 +435,15 @@ static UniValue JSONRPCExecOne(const UniValue& req)
     return rpc_result;
 }
 
+// Maximum number of requests permitted in a single JSON-RPC batch, to guard
+// against a single connection queuing an unbounded amount of work.
+static const size_t MAX_BATCH_SIZE = 100;
+
 std::string JSONRPCExecBatch(const UniValue& vReq)
 {
+    if (vReq.size() > MAX_BATCH_SIZE)
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Batch request size exceeds maximum");
+
     UniValue ret(UniValue::VARR);
     for (size_t reqIdx = 0; reqIdx < vReq.size(); reqIdx++)
         ret.push_back(JSONRPCExecOne(vReq[reqIdx]));

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -10,6 +10,10 @@
 
 using namespace std;
 
+// Maximum nesting depth of objects/arrays accepted by the parser, to guard
+// against stack exhaustion from deeply-nested untrusted JSON input.
+static const size_t MAX_JSON_DEPTH = 512;
+
 static bool json_isdigit(int ch)
 {
     return ((ch >= '0') && (ch <= '9'));
@@ -315,6 +319,8 @@ bool UniValue::read(const char *raw, size_t size)
                     setObject();
                 else
                     setArray();
+                if (stack.size() >= MAX_JSON_DEPTH)
+                    return false;
                 stack.push_back(this);
             } else {
                 UniValue tmpVal(utyp);
@@ -322,6 +328,8 @@ bool UniValue::read(const char *raw, size_t size)
                 top->values.push_back(tmpVal);
 
                 UniValue *newTop = &(top->values.back());
+                if (stack.size() >= MAX_JSON_DEPTH)
+                    return false;
                 stack.push_back(newTop);
             }
 

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -9,6 +9,7 @@
 #ifndef BITCOIN_UTILSTRENCODINGS_H
 #define BITCOIN_UTILSTRENCODINGS_H
 
+#include <algorithm>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -113,16 +114,19 @@ std::string FormatParagraph(const std::string& in, size_t width = 79, size_t ind
 
 /**
  * Timing-attack-resistant comparison.
- * Takes time proportional to length
- * of first argument.
+ * Takes time proportional to the longer of the two arguments, so that the
+ * comparison length does not depend on which argument is shorter (the previous
+ * implementation looped a.size() times and indexed b[i%b.size()], leaking the
+ * relative lengths through timing).
  */
 template <typename T>
 bool TimingResistantEqual(const T& a, const T& b)
 {
     if (b.size() == 0) return a.size() == 0;
     size_t accumulator = a.size() ^ b.size();
-    for (size_t i = 0; i < a.size(); i++)
-        accumulator |= a[i] ^ b[i%b.size()];
+    size_t n = std::max(a.size(), b.size());
+    for (size_t i = 0; i < n; i++)
+        accumulator |= (size_t)((i < a.size() ? a[i] : 0) ^ (i < b.size() ? b[i] : 0));
     return accumulator == 0;
 }
 


### PR DESCRIPTION
## What

Four NON-CONSENSUS RPC/HTTP hardening fixes (audit-verified):

1. **Timing-safe credential comparison** (`src/utilstrencodings.h`) — `TimingResistantEqual` previously looped only `a.size()` times and indexed `b[i % b.size()]`, leaking the relative lengths of the two inputs through timing. Rewritten to iterate `max(a.size(), b.size())` with per-index bounds guards. Preserves the existing empty-stored-credential early return.
2. **JSON nesting depth limit** (`src/univalue/lib/univalue_read.cpp`) — added `MAX_JSON_DEPTH = 512`; the parser now rejects (`return false`) before pushing onto the stack once the limit is reached, guarding against stack exhaustion from deeply-nested untrusted JSON.
3. **JSON-RPC batch size cap** (`src/rpc/server.cpp`) — added `MAX_BATCH_SIZE = 100`; `JSONRPCExecBatch` throws `RPC_INVALID_REQUEST` ("Batch request size exceeds maximum") for oversized batches, bounding the work a single connection can queue.
4. **HTTP request body cap** (`src/httpserver.cpp`) — replaced the ~33 MB serialization `MAX_SIZE` passed to `evhttp_set_max_body_size` with a dedicated `MAX_HTTP_REQUEST_SIZE = 10 MiB`, bounding per-connection memory use.

## Why

These are defense-in-depth fixes for the RPC/HTTP attack surface (timing side-channel on auth, resource exhaustion via nesting/batch/body size). All identified during an audit of the RPC server.

## Files touched

- `src/utilstrencodings.h`
- `src/univalue/lib/univalue_read.cpp`
- `src/rpc/server.cpp`
- `src/httpserver.cpp`

## Consensus impact: none

These changes touch only RPC/HTTP request handling and an auth-string comparison — no block/tx validation, PoW/Equihash, script interpreter, hashed/signed bytes, chainparams, or activation heights are affected.

---

**DRAFT: pending maintainer integration build + gtest.**