### PR TITLE
beta7: fix user -addnode starved/ignored by bootstrap-peer injection (+ respect -connect)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1466,6 +1466,12 @@ void ThreadOpenAddedConnections()
         }
 
         list<vector<CService> > lservAddressesToAdd(0);
+        // Numeric (IP-literal) -addnode addresses that still need a connection.
+        // Such entries cost no DNS, so a resolution failure can never explain them
+        // being unconnected -- only a transient connect failure can -- and they
+        // should be retried promptly rather than after the full 2-minute
+        // name-resolution backoff.
+        std::vector<CService> vIpLiteralAddrs;
         BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
             vector<CService> vservNode(0);
             if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
@@ -1476,6 +1482,19 @@ void ThreadOpenAddedConnections()
                     BOOST_FOREACH(const CService& serv, vservNode)
                         setservAddNodeAddresses.insert(serv);
                 }
+                // Did this entry resolve with no DNS (a bare IP literal)? If so,
+                // track its addresses so we can shorten the retry backoff below.
+                CService servLiteral;
+                if (LookupNumeric(strAddNode.c_str(), servLiteral, Params().GetDefaultPort()))
+                    BOOST_FOREACH(const CService& serv, vservNode)
+                        vIpLiteralAddrs.push_back(serv);
+            }
+            else
+            {
+                // Previously skipped silently, leaving the user with no clue why an
+                // -addnode never connected. A name that fails to resolve here will
+                // be retried on the next loop iteration.
+                LogPrintf("ThreadOpenAddedConnections: could not resolve -addnode=%s; will retry\n", strAddNode);
             }
         }
         // Attempt to connect to each IP for each addnode entry until at least one is successful per addnode entry
@@ -1498,7 +1517,23 @@ void ThreadOpenAddedConnections()
             OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
             MilliSleep(500);
         }
-        MilliSleep(120000); // Retry every 2 minutes
+        // Is any IP-literal -addnode still not connected? If so, retry it quickly
+        // (no DNS to wait on); otherwise -- only name entries pending, or all
+        // connected -- keep the longer interval so we don't hammer DNS.
+        bool fHaveIpLiteralPending = false;
+        {
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(const CService& addrLit, vIpLiteralAddrs) {
+                bool fConnected = false;
+                BOOST_FOREACH(CNode* pnode, vNodes)
+                    if (pnode->addr == addrLit) { fConnected = true; break; }
+                if (!fConnected) { fHaveIpLiteralPending = true; break; }
+            }
+        }
+        // IP-literal -addnode entries need no DNS, so retry them quickly instead of
+        // waiting the full 2-minute name-resolution backoff; name entries keep the
+        // longer interval so we don't hammer DNS.
+        MilliSleep(fHaveIpLiteralPending ? 15000 : 120000);
     }
 }
 


### PR DESCRIPTION
## What

Headline beta7 networking fix: make user-supplied `-addnode=` connect reliably and not be starved/ignored by the bootstrap-peer auto-injection.

### src/net.cpp — `ThreadOpenAddedConnections`
- **DNS-failure visibility:** when an `-addnode` name fails to resolve, `LogPrintf` it instead of silently dropping it. A misconfigured or temporarily-unreachable `-addnode` is now visible in the debug log (`could not resolve -addnode=<x>; will retry`).
- **Fast retry for IP-literal addnodes:** entries that resolve with no DNS (detected via `LookupNumeric`) are tracked. When any such IP-literal peer is still not connected after the connect pass, the loop sleeps **15s** instead of the full **120s** name-resolution backoff, so a bare-IP `-addnode` reconnects promptly after a transient connect failure. Name (DNS) entries keep the 120s interval so we don't hammer DNS.

### src/init.cpp — bootstrap-peer injection (already correct on master)
The two other parts of the reported bug were already fixed on master in commit `0517f09316` ("peer-discovery: fix fresh nodes stuck at 'syncing 0'"), so no change was needed there. Verified during this work:
- **Respect `-connect`:** the bootstrap-peer injection is wrapped in `if (!mapArgs.count("-connect")) { ... }` — a user using `-connect` gets only their pinned peers.
- **Don't starve user `-addnode`:** the injection `push_back`s bootstrap peers onto `mapMultiArgs["-addnode"]`, which is already populated with the user's CLI/conf `-addnode` entries — so user entries stay **first** in `vAddedNodes` (attempted first), and a `std::find` check de-duplicates a bootstrap peer the user already listed.

## Why
Users reported that a hand-configured `-addnode` did not reliably connect because the daemon auto-injects `Params().BootstrapPeers()` as persistent `-addnode` on every start. Master already orders user entries first and skips injection under `-connect`; the remaining gap was the connection scheduler: a failed-to-resolve name was invisible, and an IP-literal `-addnode` that hit a transient failure waited a full 2 minutes before retry. Audit-verified against the existing loop semantics; `LookupNumeric`/`ToStringIP`/`CService::operator==` are all already declared via `net.h -> netbase.h`.

## Files touched
- `src/net.cpp` (only)

## Consensus impact: none
Outbound peer-connection scheduling and log output only — no change to block/tx validation, PoW/Equihash, the script interpreter, serialization, chainparams, or activation heights.

DRAFT: pending maintainer integration build + gtest.