### PR TITLE
beta7: perf tuning — leveldb max_open_files scaling + HTTP workqueue defaults

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -21,7 +21,17 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
-    options.max_open_files = 64;
+    // Scale the open-file cache with the configured DB cache so a large block
+    // index doesn't thrash file descriptors (matches Bitcoin Core's later
+    // scaling): 64 for small caches, up to 1000 for large ones. Each ~2MiB
+    // table is held open via these, so this is purely an I/O/FD tuning and
+    // does not change any stored or computed value.
+    options.max_open_files = 1000;
+    if (nCacheSize < 100 * 1048576) {
+        // Use the conservative default for small caches (e.g. unit tests,
+        // low-memory configs) to keep FD usage modest.
+        options.max_open_files = 64;
+    }
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
         // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
         // on corruption in later versions.

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -11,8 +11,11 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/function.hpp>
 
-static const int DEFAULT_HTTP_THREADS=4;
-static const int DEFAULT_HTTP_WORKQUEUE=16;
+// Raised from 4/16 to avoid "Work queue depth exceeded" HTTP 500s under load
+// (e.g. wallet/GUI bursts of concurrent RPC calls). Still user-overridable via
+// -rpcthreads / -rpcworkqueue; config-only, no consensus or value impact.
+static const int DEFAULT_HTTP_THREADS=8;
+static const int DEFAULT_HTTP_WORKQUEUE=256;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 
 struct evhttp_request;


### PR DESCRIPTION
## What

Two low-risk operational tuning changes (constants/config only):

1. **`src/dbwrapper.cpp`** — `leveldb::Options::max_open_files` was hardcoded to 64, causing file-descriptor thrash on a large block index. Now scales with the configured DB cache (matching Bitcoin Core's later scaling): 64 for small caches (<100 MiB, e.g. unit tests / low-memory configs), up to 1000 for large ones.
2. **`src/httpserver.h`** — `DEFAULT_HTTP_THREADS` 4→8 and `DEFAULT_HTTP_WORKQUEUE` 16→256. The old defaults caused "Work queue depth exceeded" HTTP 500s under load (wallet/GUI bursts of concurrent RPC). Still user-overridable via `-rpcthreads` / `-rpcworkqueue`.

## Why

Reduce FD thrash on large indexes and eliminate RPC 500s under concurrent load, with no functional change.

## Files

- `src/dbwrapper.cpp`
- `src/httpserver.h`

## Consensus impact: none

No change to block/tx validation, PoW, script, serialization, chainparams, or activation heights. These touch only the leveldb open-file cache (an I/O/FD knob) and HTTP server thread/queue defaults.

## Behavior preserved

No computed value changes (balances, coin selection, stored data unaffected). Both HTTP defaults remain user-overridable.

---

**DRAFT: pending maintainer build.**