### PR TITLE
beta7: -addnode phase-2 — respect -connect + prioritize user -addnode over injected bootstrap peers

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2563,8 +2563,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // the CConnman added-node list without lock-ordering hazards, which does
     // not exist yet.
     if (!mapArgs.count("-connect")) {
+        // Append the bootstrap peers AFTER any user-supplied -addnode entries
+        // (which are already present in this vector from ParseParameters), so
+        // ThreadOpenAddedConnections attempts the user's peers first and the
+        // injected bootstrap peers only as a fallback. De-duplicate: skip any
+        // bootstrap peer the user already pinned. Never starves user entries.
+        std::vector<std::string>& addnodes = mapMultiArgs["-addnode"];
         BOOST_FOREACH(const std::string& peer, GetBootstrapPeerList()) {
-            std::vector<std::string>& addnodes = mapMultiArgs["-addnode"];
             if (std::find(addnodes.begin(), addnodes.end(), peer) == addnodes.end()) {
                 addnodes.push_back(peer);
                 LogPrintf("Adding bootstrap peer %s as a persistent sync node\n", peer);


### PR DESCRIPTION
## What

Finishes the `-addnode` fix (the init.cpp half; PR #125 added the net.cpp DNS-failure logging + fast IP-literal retry). One small, behavior-preserving change to the bootstrap-peer injection in `src/init.cpp` (`AppInit2`, the `if (!mapArgs.count("-connect"))` block):

1. **Respect `-connect`** — the whole bootstrap-peer injection is gated behind `if (!mapArgs.count("-connect"))`, so a user who passes `-connect` gets ONLY their peers and no injected bootstrap peers. (This guard already landed in 0517f093; this PR documents and tightens the block alongside the ordering guarantee.)
2. **Do not starve user entries** — user-supplied `-addnode` entries are already present in `mapMultiArgs["-addnode"]` (from `ParseParameters`) before this loop runs; bootstrap peers are appended AFTER them with `push_back` and de-duplicated (`std::find` skips any bootstrap peer the user already pinned). `ThreadOpenAddedConnections` copies this vector in order (`vAddedNodes = mapMultiArgs["-addnode"]`) and dials it in order, so user peers are attempted first and injected bootstrap peers serve only as a fallback.

The reference to `mapMultiArgs["-addnode"]` is now hoisted out of the loop and a comment documents the user-first / bootstrap-after / de-dup contract so future edits don't accidentally reorder it.

## Why

Fresh / peer-starved nodes pin the compiled bootstrap peers as persistent `-addnode` to avoid hanging at 0 connections. A user who explicitly configures `-connect` or their own `-addnode` peers should keep control: `-connect` must suppress the injection entirely, and an explicit `-addnode` should be dialed before the fallback bootstrap peers.

## Files

- `src/init.cpp` — bootstrap-peer injection block in `AppInit2`.

## Consensus impact: none

Networking-only (peer connection policy). No change to block/tx validation, PoW, script, serialization, chainparams, or activation heights. No computed value changes (balances/selection unaffected). Connection ordering, de-dup, and the `-connect` gate are functionally identical to master; this commit only documents the contract and removes a redundant per-iteration reference rebind.

DRAFT: pending maintainer build verification.