### PR TITLE
Activate ZIP-209 shielded turnstile on mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -202,6 +202,21 @@ public:
             1138            // * recent transactions/day (measured: ~1.0 tx/block, ~1138 blocks/day)
         };
 
+        // ZIP-209: reject any block that drives a shielded value pool balance
+        // negative (turnstile enforcement). Previously configured on testnet
+        // only; this mirrors that for mainnet. The hardcoded Sprout checkpoint
+        // re-seeds nChainSproutValue for nodes whose block index predates pool
+        // monitoring, so they can enforce from this height forward WITHOUT a full
+        // reindex; nodes that tracked the pool from genesis instead assert their
+        // computed balance equals this value, so it MUST be the exact genesis-
+        // derived Sprout balance at this block. Verified on a synced mainnet node:
+        //   getblock 0000038aee939c8017f4ad353e3fd1313c6a0da565bbc1d3269bbe855fe33505
+        //   -> valuePools[id=sprout].chainValueZat == 1316412375709  (height 3000000)
+        nSproutValuePoolCheckpointHeight = 3000000;
+        nSproutValuePoolCheckpointBalance = 1316412375709;
+        fZIP209Enabled = true;
+        hashSproutValuePoolCheckpointBlock = uint256S("0000038aee939c8017f4ad353e3fd1313c6a0da565bbc1d3269bbe855fe33505");
+
         fastSyncAnchorData.nHeight = 3126937;
         fastSyncAnchorData.hashBlock = uint256S("0x00000663e40f1fe0bc32a7e7282fac25de5fe8ecefd9c627e2fd948d388f7053");
         fastSyncAnchorData.hashAnchorSha256 = uint256S("0x376d6d5e6f7d02459b89ae0988f5c51bb1deaf2a3e4b3a1de745e4f2e3bb279d");


### PR DESCRIPTION
## ⚠️ This is a soft fork — needs coordinated deployment
This is a consensus rule-tightening. Non-upgraded nodes will **not** reject a pool-negative block that upgraded nodes reject, so a coordinated upgrade (miners / exchanges / nodes) is required to avoid a chain split. Please treat this as a network-upgrade proposal, not a routine merge.

## What it changes
In `CMainParams`, sets the Sprout value-pool checkpoint and enables enforcement:
- height `3000000`, balance `1316412375709` zat, block `0000038aee939c8017f4ad353e3fd1313c6a0da565bbc1d3269bbe855fe33505`
- `fZIP209Enabled = true`

The enforcement code already exists in `ConnectBlock` (inherited); this only activates it on mainnet, mirroring the existing testnet configuration.

## Why
Bounds the damage of any shielded-circuit soundness bug: value forged inside a pool cannot be withdrawn past the pool boundary undetected. The checkpoint balance was read from a synced mainnet node and is the exact genesis-derived Sprout balance at height 3,000,000 — verifiable: `getblock 0000038aee939c8017f4ad353e3fd1313c6a0da565bbc1d3269bbe855fe33505` → `valuePools[id=sprout].chainValueZat == 1316412375709`.