### PR TITLE
Fix NULL-pointer dereference on the genesis block during -reindex / import

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4473,7 +4473,11 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
         return false;
 
 
-    if (!pindexPrev->IsValid(BLOCK_VALID_SCRIPTS)) {
+    // pindexPrev is NULL for the genesis block (set only for non-genesis above).
+    // The genesis block has no ancestors, so the invalid-ancestor walk below is
+    // meaningless for it; guard the dereference to avoid a NULL segfault during
+    // -reindex / import, where LoadExternalBlockFile re-accepts the genesis header.
+    if (pindexPrev != NULL && !pindexPrev->IsValid(BLOCK_VALID_SCRIPTS)) {
         for (const CBlockIndex *failedit : g_failed_blocks) {
             if (pindexPrev->GetAncestor(failedit->nHeight) == failedit) {
                 assert(failedit->nStatus & BLOCK_FAILED_MASK);


### PR DESCRIPTION
## Summary
`AcceptBlockHeader` dereferenced `pindexPrev` for the genesis block (which has no predecessor) → segfault that aborts every `-reindex` / block import at startup. Guard the genesis case.

Reliability fix; no consensus change.